### PR TITLE
Make the use of `python` consistent

### DIFF
--- a/cherry_picker/readme.rst
+++ b/cherry_picker/readme.rst
@@ -26,9 +26,9 @@ Requires Python 3.6.
 
     $ git clone https://github.com/python/core-workflow.git
     $ cd core-workflow/cherry_picker
-    $ python3 -m venv venv
+    $ python -m venv venv
     $ source venv/bin/activate
-    (venv) $ python3 -m pip install -r requirements.txt
+    (venv) $ python -m pip install -r requirements.txt
     (venv) $ git clone https://github.com/<username>/cpython.git  # your own cpython fork
     (venv) $ cd cpython
     (venv) $ git remote add upstream https://github.com/python/cpython.git


### PR DESCRIPTION
Accidentally introduced `python3` usage over `python` in a previous commit.