### PR TITLE
Make cherry picker as a script

### DIFF
--- a/cherry_picker/__main__.py
+++ b/cherry_picker/__main__.py
@@ -1,0 +1,4 @@
+from .cherry_picker import cherry_pick_cli
+
+if __name__ == '__main__':
+    cherry_pick_cli()

--- a/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker.py
@@ -257,7 +257,7 @@ def cherry_pick_cli(dry_run, pr_remote, abort, status, commit_sha1, branches):
     pyconfig_path = os.path.join(current_dir, '/pyconfig.h.in')
 
     if not os.path.exists(pyconfig_path):
-        os.chdir(os.path.join(current_dir, 'cpython'))
+        os.chdir(os.path.join(os.getcwd(), 'cpython'))
 
     if dry_run:
        click.echo("Dry run requested, listing expected command sequence")


### PR DESCRIPTION
Relate to #64 #69 

*I'm not sure if this change will break other bot or something.*

This commit make cherry-picker more easier to use, you don't need to let `cpython` folder under `cherry_picker` anymore.

Example:
```
$ ls
cpython   # Assume we already clone cpython in our dev dir and upstream setting
$ git clone https://github.com/python/core-workflow.git
$ cd core-workflow
$ python -m venv venv
$ source venv/bin/activate
(venv) $ python -m pip install -r cherry_picker/requirements.txt
(venv) $ cp -r cherry_picker venv/lib/python3.6/site-packages/
(venv) $ cd ..
(venv) $ python -m cherry_picker deadbeaf 3.6
```
