### PR TITLE
Support `-h`

### DIFF
--- a/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker.py
@@ -251,7 +251,9 @@ To abort the cherry-pick and cleanup:
             click.echo(u"Currently in `master` branch.  Will not continue. \U0001F61B")
 
 
-@click.command()
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+
+@click.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--dry-run', is_flag=True,
               help="Prints out the commands, but not executed.")
 @click.option('--push', 'pr_remote', metavar='REMOTE',


### PR DESCRIPTION
Closes https://github.com/python/core-workflow/issues/88
```
$ python -m cherry_picker -h
Usage: cherry_picker.py [OPTIONS] [COMMIT_SHA1] [BRANCHES]...

Options:
  --dry-run           Prints out the commands, but not executed.
  --push REMOTE       git remote to use for PR branches
  --abort             Abort current cherry-pick and clean up branch
  --continue          Continue cherry-pick, push, and clean up branch
  --status            Get the status of cherry-pick
  --push / --no-push  Changes won't be pushed to remote
  -h, --help          Show this message and exit.
```