### PR TITLE
Add instructions to README for cherry_picker to install wheel

### DIFF
--- a/cherry_picker/readme.rst
+++ b/cherry_picker/readme.rst
@@ -30,6 +30,7 @@ Requires Python 3.6.
     $ cd core-workflow
     $ python3 -m venv venv
     $ source venv/bin/activate
+    (venv) $ python -m pip install wheel
     (venv) $ python -m pip install --upgrade .
 
 Specify an `upstream` remote in the cloned CPython repository::


### PR DESCRIPTION
By default, my venv did not have wheel installed, so I needed to install it before running the pip install for cherry_picker.

Closes https://github.com/python/core-workflow/issues/103