### PR TITLE
Rename PR remote option to --pr-remote

### DIFF
--- a/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker.py
@@ -254,7 +254,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--dry-run', is_flag=True,
               help="Prints out the commands, but not executed.")
-@click.option('--push', 'pr_remote', metavar='REMOTE',
+@click.option('--pr-remote', 'pr_remote', metavar='REMOTE',
               help='git remote to use for PR branches', default='origin')
 @click.option('--abort', 'abort', flag_value=True, default=None,
               help="Abort current cherry-pick and clean up branch")

--- a/cherry_picker/readme.rst
+++ b/cherry_picker/readme.rst
@@ -1,6 +1,6 @@
 Usage (from a cloned CPython directory) ::
    
-   cherry_picker [--push REMOTE] [--dry-run] [--status] [--abort/--continue] [--no-push] <commit_sha1> <branches>
+   cherry_picker [--pr-remote REMOTE] [--dry-run] [--status] [--abort/--continue] [--no-push] <commit_sha1> <branches>
    
 
 .. contents::
@@ -43,8 +43,8 @@ cherry-pick branches. Otherwise, `origin` is used for that purpose.
 
 By default, the PR branches used to submit pull requests back to the main
 repository are pushed to `origin`. If this is incorrect, then the correct
-remote will need be specified using the ``--push`` option (e.g.
-``--push pr`` to use a remote named ``pr``).
+remote will need be specified using the ``--pr-remote`` option (e.g.
+``--pr-remote pr`` to use a remote named ``pr``).
 
 
 Cherry-picking :snake: :cherries: :pick:
@@ -77,9 +77,9 @@ Options
 
 ::
 
-    -- dry-run      Dry Run Mode.  Prints out the commands, but not executed.
-    -- push REMOTE  Specify the git remote to push into.  Default is 'origin'.
-    -- status       Do `git status` in cpython directory.
+    -- dry-run           Dry Run Mode.  Prints out the commands, but not executed.
+    -- pr-remote REMOTE  Specify the git remote to push into.  Default is 'origin'.
+    -- status            Do `git status` in cpython directory.
 
 
 Additional options::
@@ -142,7 +142,7 @@ In case of merge conflicts or errors, the following message will be displayed::
 Passing the `--dry-run` option will cause the script to print out all the
 steps it would execute without actually executing any of them. For example::
 
-    $ cherry_picker --dry-run --push pr 1e32a1be4a1705e34011770026cb64ada2d340b5 3.6 3.5
+    $ cherry_picker --dry-run --pr-remote pr 1e32a1be4a1705e34011770026cb64ada2d340b5 3.6 3.5
     Dry run requested, listing expected command sequence
     fetching upstream ...
     dry_run: git fetch origin
@@ -160,6 +160,12 @@ steps it would execute without actually executing any of them. For example::
     dry_run: Create new PR: https://github.com/python/cpython/compare/3.5...ncoghlan:backport-1e32a1b-3.5?expand=1
     dry_run: git checkout master
     dry_run: git branch -D backport-1e32a1b-3.5
+
+`--pr-remote` option
+-----------------
+
+This will generate pull requests through a remote other than ``origin``
+(e.g. ``pr``)
 
 
 `--status` option


### PR DESCRIPTION
The new --push/--no-push option conflicts with the old name
of the option for setting the PR remote.

This updates the latter option to the more explicit
`--pr-remote`.