### PR TITLE
Simplify username parsing

### DIFF
--- a/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker.py
@@ -42,11 +42,8 @@ class CherryPicker:
         raw_result = subprocess.check_output(cmd.split(),
                                              stderr=subprocess.STDOUT)
         result = raw_result.decode('utf-8')
-        if result.startswith(("https://", "ssh://")):
-            proto,_, domain, username, *_ = result.split('/')
-        else:
-            username_end = result.index('/cpython.git')
-            username = result[len("git@github.com:"):username_end]
+        # implicit ssh URIs use : to separate host from user, others just use /
+        username = result.replace(':', '/').split('/')[-2]
         return username
 
     def get_cherry_pick_branch(self, maint_branch):

--- a/cherry_picker/test.py
+++ b/cherry_picker/test.py
@@ -1,5 +1,7 @@
 from unittest import mock
 
+import pytest
+
 from .cherry_picker import get_base_branch, get_current_branch, \
     get_full_sha_from_short, CherryPicker
 
@@ -69,26 +71,20 @@ def test_get_pr_url(subprocess_check_output, os_path_exists):
            == "https://github.com/python/cpython/compare/3.6...mock_user:backport-22a594a-3.6?expand=1"
 
 
-@mock.patch('os.path.exists')
-@mock.patch('subprocess.check_output')
-def test_username_ssh(subprocess_check_output, os_path_exists):
-    os_path_exists.return_value = True
-    subprocess_check_output.return_value = b'git@github.com:mock_user/cpython.git'
-    branches = ["3.6"]
-    cp = CherryPicker('origin', '22a594a0047d7706537ff2ac676cdc0f1dcb329c',
-                      branches)
-    assert cp.username == 'mock_user'
-
-
-@mock.patch('os.path.exists')
-@mock.patch('subprocess.check_output')
-def test_username_https(subprocess_check_output, os_path_exists):
-    os_path_exists.return_value = True
-    subprocess_check_output.return_value = b'https://github.com/mock_user/cpython.git'
-    branches = ["3.6"]
-    cp = CherryPicker('origin', '22a594a0047d7706537ff2ac676cdc0f1dcb329c',
-                      branches)
-    assert cp.username == 'mock_user'
+@pytest.mark.parametrize('url', [
+    b'git@github.com:mock_user/cpython.git',
+    b'git@github.com:mock_user/cpython',
+    b'ssh://git@github.com/mock_user/cpython.git',
+    b'ssh://git@github.com/mock_user/cpython',
+    b'https://github.com/mock_user/cpython.git',
+    b'https://github.com/mock_user/cpython',
+    ])
+def test_username(url):
+    with mock.patch('subprocess.check_output', return_value=url):
+        branches = ["3.6"]
+        cp = CherryPicker('origin', '22a594a0047d7706537ff2ac676cdc0f1dcb329c',
+                          branches)
+        assert cp.username == 'mock_user'
 
 
 @mock.patch('os.path.exists')


### PR DESCRIPTION
I've been carrying around a patch that removed the `.git` from the end of `username_end =` line, but it broke with a recent pull, motivating me to fix it properly and submit it.

@Carreau, could you confirm that the `ssh://` URLs I included in the test match what yours look like that you mentioned in #104?