### PR TITLE
Make tests verbose on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ cache: pip
 install:
     - pip install -r cherry_picker/requirements.txt
 script:
-    - pytest cherry_picker/test.py
+    - pytest cherry_picker/test.py -v


### PR DESCRIPTION
`-v` makes it easier to see that any added tests are indeed running as expected.