### PR TITLE
cherry_picker now can only be run from CPython repo

### DIFF
--- a/cherry_picker/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker/cherry_picker.py
@@ -271,11 +271,10 @@ def cherry_pick_cli(dry_run, pr_remote, abort, status, push,
                     commit_sha1, branches):
 
     click.echo("\U0001F40D \U0001F352 \u26CF")
-    current_dir = os.getcwd()
-    pyconfig_path = os.path.join(current_dir, 'pyconfig.h.in')
 
-    if not os.path.exists(pyconfig_path):
-        os.chdir(os.path.join(current_dir, 'cpython'))
+    if not is_cpython_repo():
+        click.echo("You're not inside a CPython repo right now! 🙅")
+        sys.exit(-1)
 
     if dry_run:
         click.echo("Dry run requested, listing expected command sequence")
@@ -318,6 +317,15 @@ def get_full_sha_from_short(short_sha):
     output = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT)
     full_sha = output.strip().decode('utf-8').split('\n')[0].split()[1]
     return full_sha
+
+
+def is_cpython_repo():
+    cmd = "git log -r 7f777ed95a19224294949e1b4ce56bbffcb1fe9f"
+    try:
+        subprocess.check_output(cmd.split(), stderr=subprocess.STDOUT)
+    except subprocess.SubprocessError:
+        return False
+    return True
 
 
 if __name__ == '__main__':

--- a/cherry_picker/cherry_picker/test.py
+++ b/cherry_picker/cherry_picker/test.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 
 from .cherry_picker import get_base_branch, get_current_branch, \
-    get_full_sha_from_short, CherryPicker
+    get_full_sha_from_short, is_cpython_repo, CherryPicker
 
 
 def test_get_base_branch():
@@ -97,3 +97,18 @@ def test_get_updated_commit_message(subprocess_check_output, os_path_exists):
                       branches)
     assert cp.get_commit_message('22a594a0047d7706537ff2ac676cdc0f1dcb329c') \
            == 'bpo-123: Fix Spam Module (GH-113)'
+
+@mock.patch('subprocess.check_output')
+def test_is_cpython_repo(subprocess_check_output):
+    subprocess_check_output.return_value = """commit 7f777ed95a19224294949e1b4ce56bbffcb1fe9f
+Author: Guido van Rossum <guido@python.org>
+Date:   Thu Aug 9 14:25:15 1990 +0000
+
+    Initial revision
+
+"""
+    assert is_cpython_repo() == True
+
+def test_is_not_cpython_repo():
+    assert is_cpython_repo() == False
+


### PR DESCRIPTION
It can now be run from anywhere in CPython repo.
The logic to detect if we are in CPython repo or not, is borrowed from blurb.

This removes the functionality where it tries to `cd` to a cpython directory within cherry_picker.