### PR TITLE
Add vi to fallbacks list

### DIFF
--- a/blurb/blurb.py
+++ b/blurb/blurb.py
@@ -752,7 +752,7 @@ def find_editor():
     if sys.platform == 'win32':
         fallbacks = ['notepad.exe']
     else:
-        fallbacks = ['/etc/alternatives/editor', 'nano']
+        fallbacks = ['/etc/alternatives/editor', 'nano', 'vi']
     for fallback in fallbacks:
         if os.path.isabs(fallback):
             found_path = fallback


### PR DESCRIPTION
If EDITOR or GIT_EDITOR is not set, we use a fallback editor, but on
non-windows only "nano" was listed, and it is not installed by default
on recent Linux distributions, while vi is practically everywhere.

Fixes #154 