### PR TITLE
Consider git's core.editor configuration

### DIFF
--- a/blurb/blurb.py
+++ b/blurb/blurb.py
@@ -750,6 +750,16 @@ Run unit tests.  Only works inside source repo, not when installed.
     print(tests_run, "tests passed.")
 
 
+def git_core_editor():
+    try:
+        return run('git config --get core.editor').strip()
+    except subprocess.CalledProcessError as e:
+        if e.returncode == 1:
+            # core.editor not configured
+            return None
+        raise
+
+
 def find_editor():
     # Try environment variables. Check more specific settings first so
     # they can override less specific values.
@@ -779,20 +789,10 @@ def find_editor():
         if found_path and os.path.exists(found_path):
             return found_path
 
-    # For simplicity, recommend the old EDITOR environment varibale. Advanced
-    # users should consult the documention if they want to use more specific
-    # confguration.
+    # For simplicity, recommend the old EDITOR environment variable.
+    # Advanced users should consult the documentation if they want to
+    # use more specific configuration.
     error('Could not find an editor! Set the EDITOR environment variable.')
-
-
-def git_core_editor():
-    try:
-        return run('git config --get core.editor').strip()
-    except subprocess.CalledProcessError as e:
-        if e.returncode == 1:
-            # core.etitor not configured
-            return None
-        raise
 
 
 @subcommand

--- a/blurb/blurb.py
+++ b/blurb/blurb.py
@@ -751,10 +751,22 @@ Run unit tests.  Only works inside source repo, not when installed.
 
 
 def find_editor():
+    # Try environment variables. Check more specific settings first so
+    # they can override less specific values.
     for var in 'GIT_EDITOR', 'EDITOR':
         editor = os.environ.get(var)
         if editor is not None:
             return editor
+
+    # Try git configuration - this checks both project configuration
+    # (.git/config) and global configuration (~/.gitconfig).
+    editor = git_core_editor()
+    if editor:
+        return editor
+
+    # Try to use a user friendly platform specific fallback. We
+    # intentionally not using 'vi' as a fallback, assuming that fallback
+    # is needed for new users.
     if sys.platform == 'win32':
         fallbacks = ['notepad.exe']
     else:
@@ -766,7 +778,21 @@ def find_editor():
             found_path = shutil.which(fallback)
         if found_path and os.path.exists(found_path):
             return found_path
+
+    # For simplicity, recommend the old EDITOR environment varibale. Advanced
+    # users should consult the documention if they want to use more specific
+    # confguration.
     error('Could not find an editor! Set the EDITOR environment variable.')
+
+
+def git_core_editor():
+    try:
+        return run('git config --get core.editor').strip()
+    except subprocess.CalledProcessError as e:
+        if e.returncode == 1:
+            # core.etitor not configured
+            return None
+        raise
 
 
 @subcommand


### PR DESCRIPTION
Git core.editor is likely to be set, use it if set.

Fixes: #154 