### PR TITLE
Abort "blurb add" cleanly

### DIFF
--- a/blurb/blurb.py
+++ b/blurb/blurb.py
@@ -813,7 +813,11 @@ Add a blurb (a Misc/NEWS entry) to the current CPython repo.
             print()
             print("Error: {}".format(failure))
             print()
-            prompt("Hit return to retry (or Ctrl-C to abort)")
+            try:
+                prompt("Hit return to retry (or Ctrl-C to abort)")
+            except KeyboardInterrupt:
+                print()
+                return
             print()
             continue
         break


### PR DESCRIPTION
If the user aborted the operation by hitting Control+C, abort the
operation without a traceback.

Example run:

    $ blurb
    (Terminate editor without any change)

    Error: Error in /tmp/tmpt0etkaf2.rst:26:
    Blurb 'body' text must not be empty!

    [Hit return to retry (or Ctrl-C to abort)> ^C
    $