### PR TITLE
blurb: small usability improvements

### DIFF
--- a/blurb/blurb.py
+++ b/blurb/blurb.py
@@ -677,7 +677,7 @@ If subcommand is not specified, prints one-line summaries for every command.
         summaries = []
         longest_name_len = -1
         for name, fn in subcommands.items():
-            if name == '--help':
+            if name.startswith('-'):
                 continue
             longest_name_len = max(longest_name_len, len(name))
             if not fn.__doc__:

--- a/blurb/blurb.py
+++ b/blurb/blurb.py
@@ -639,7 +639,7 @@ def chdir_to_repo_root():
 
 def error(*a):
     s = " ".join(str(x) for x in a)
-    sys.exit("Error: " + s)
+    sys.exit("Error: " + s + "\nRun 'blurb help' for help.")
 
 
 subcommands = {}
@@ -726,6 +726,9 @@ If subcommand is not specified, prints one-line summaries for every command.
     print()
     print(doc)
     sys.exit(0)
+
+# Make "blurb --help" work.
+subcommands["--help"] = help
 
 
 @subcommand

--- a/blurb/blurb.py
+++ b/blurb/blurb.py
@@ -639,7 +639,7 @@ def chdir_to_repo_root():
 
 def error(*a):
     s = " ".join(str(x) for x in a)
-    sys.exit("Error: " + s + "\nRun 'blurb help' for help.")
+    sys.exit("Error: " + s)
 
 
 subcommands = {}
@@ -653,7 +653,7 @@ def subcommand(fn):
 def get_subcommand(subcommand):
     fn = subcommands.get(subcommand)
     if not fn:
-        error("Unknown subcommand: {}".format(subcommand))
+        error("Unknown subcommand: {}\nRun 'blurb help' for help.".format(subcommand))
     return fn
 
 
@@ -677,6 +677,8 @@ If subcommand is not specified, prints one-line summaries for every command.
         summaries = []
         longest_name_len = -1
         for name, fn in subcommands.items():
+            if name == '--help':
+                continue
             longest_name_len = max(longest_name_len, len(name))
             if not fn.__doc__:
                 error("help is broken, no docstring for " + fn.__name__)


### PR DESCRIPTION
These would have made my first experience using blurb just now smoother.
- Make `blurb --help` work in addition to `blurb help`. This is my default command for figuring out how to use a command; for example, `mypy --help`, `pip --help`, and `flit --help` all give me useful info.
- Suggest looking at `blurb help` if the user gave an invalid command.