### PR TITLE
Add -f to blurb to include files even if ignored

### DIFF
--- a/blurb/blurb.py
+++ b/blurb/blurb.py
@@ -1046,7 +1046,7 @@ Python News
 git_add_files = []
 def flush_git_add_files():
     if git_add_files:
-        subprocess.run(["git", "add", *git_add_files], stdout=subprocess.PIPE, stderr=subprocess.PIPE).check_returncode()
+        subprocess.run(["git", "add", "-f", *git_add_files], stdout=subprocess.PIPE, stderr=subprocess.PIPE).check_returncode()
         git_add_files.clear()
 
 git_rm_files = []


### PR DESCRIPTION
Users might have a .gitignore configuration where they ignore folders like "Lib", "Build" "Misc" or other paths that might lead to blurb not being able to add the files using just "git add". This change makes git to "force" the addition of the files passed in, ensuring that even if present in gitignore they will be added to the commit, rather than blurb just failing in the operation.

Sending the patch as it just happened to me 😄 