### PR TITLE
Improve error report on subprocess exceptions for blurb

### DIFF
--- a/blurb/blurb.py
+++ b/blurb/blurb.py
@@ -1596,6 +1596,10 @@ def main():
         print()
         print("usage: ", end="")
         help(subcommand)
+    except subprocess.SubprocessError as e:
+        output = e.stdout.decode() + e.stderr.decode()
+        print("Failed running {}, output: \n{}".format(e.cmd, output))
+        raise
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
At the moment when a subprocess command fails the error output is not meaningful at all. By logging the command run and the output that it produced the user can get a further insight into the root of the issue.

How errors are reported to the user at the moment:
```
$ blurb add
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.6/bin/blurb", line 11, in <module>
    sys.exit(main())
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/blurb.py", line 1562, in main
    sys.exit(fn(*filtered_args, **kwargs))
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/blurb.py", line 890, in add
    flush_git_add_files()
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/blurb.py", line 1049, in flush_git_add_files
    subprocess.run(["git", "add", *git_add_files], stdout=subprocess.PIPE, stderr=subprocess.PIPE).check_returncode()
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/subprocess.py", line 369, in check_returncode
    self.stderr)
subprocess.CalledProcessError: Command '['git', 'add', '/Users/mcorcherojim/workspace/mariocj89/cpython/Misc/NEWS.d/next/Library/2017-10-17-20-02-35.bpo-30541.DVmfDs.rst']' returned non-zero exit status 1.
```

How they will be reported with this change:
```
$ blurb add
Failed running ['git', 'add', '/Users/mcorcherojim/workspace/mariocj89/cpython/Misc/NEWS.d/next/Library/2017-10-17-19-58-24.bpo-30541.DVmfDs.rst'], output:
The following paths are ignored by one of your .gitignore files:
Misc/NEWS.d/next/Library/2017-10-17-19-58-24.bpo-30541.DVmfDs.rst
Use -f if you really want to add them.

Traceback (most recent call last):
  File "../cpython-core-workflow/blurb/blurb.py", line 1606, in <module>
    main()
  File "../cpython-core-workflow/blurb/blurb.py", line 1562, in main
    sys.exit(fn(*filtered_args, **kwargs))
  File "../cpython-core-workflow/blurb/blurb.py", line 890, in add
    flush_git_add_files()
  File "../cpython-core-workflow/blurb/blurb.py", line 1049, in flush_git_add_files
    subprocess.run(["git", "add", *git_add_files], stdout=subprocess.PIPE, stderr=subprocess.PIPE).check_returncode()
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/subprocess.py", line 369, in check_returncode
    self.stderr)
subprocess.CalledProcessError: Command '['git', 'add', '/Users/mcorcherojim/workspace/mariocj89/cpython/Misc/NEWS.d/next/Library/2017-10-17-19-58-24.bpo-30541.DVmfDs.rst']' returned non-zero exit status 1.
```