### PR TITLE
Add another empty line before the Co-Authored-by line.

### DIFF
--- a/cherry_picker/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker/cherry_picker.py
@@ -152,6 +152,7 @@ To abort the cherry-pick and cleanup:
         updated_commit_message = f"""{commit_prefix}{self.get_commit_message(self.commit_sha1)}
 (cherry picked from commit {self.commit_sha1})
 
+
 Co-authored-by: {get_author_info_from_short_sha(self.commit_sha1)}"""
         updated_commit_message = updated_commit_message.replace('#', 'GH-')
         if self.dry_run:
@@ -301,6 +302,7 @@ To abort the cherry-pick and cleanup:
             co_author_info = f"Co-authored-by: {get_author_info_from_short_sha(short_sha)}"
             updated_commit_message = f"""[{base}] {commit_message}.
 (cherry picked from commit {full_sha})
+
 
 {co_author_info}"""
             if self.dry_run:

--- a/cherry_picker/cherry_picker/test.py
+++ b/cherry_picker/cherry_picker/test.py
@@ -117,6 +117,7 @@ In Sphinx 1.4.9, the sourcename was "index.txt".
 In Sphinx 1.5.1+, it is now "index.rst.txt".
 (cherry picked from commit b9ff498793611d1c6a9b99df464812931a1e2d69)
 
+
 Co-authored-by: Elmar Ritsch <35851+elritsch@users.noreply.github.com>"""
     title, body = normalize_commit_message(commit_message)
     assert title == "[3.6] Fix broken `Show Source` links on documentation pages (GH-3113)"
@@ -125,6 +126,7 @@ In Sphinx 1.4.9, the sourcename was "index.txt".
 In Sphinx 1.5.1+, it is now "index.rst.txt".
 (cherry picked from commit b9ff498793611d1c6a9b99df464812931a1e2d69)
 
+
 Co-authored-by: Elmar Ritsch <35851+elritsch@users.noreply.github.com>"""
 
 def test_normalize_short_commit_message():
@@ -132,9 +134,11 @@ def test_normalize_short_commit_message():
 
 (cherry picked from commit b9ff498793611d1c6a9b99df464812931a1e2d69)
 
+
 Co-authored-by: Elmar Ritsch <35851+elritsch@users.noreply.github.com>"""
     title, body = normalize_commit_message(commit_message)
     assert title == "[3.6] Fix broken `Show Source` links on documentation pages (GH-3113)"
     assert body == """(cherry picked from commit b9ff498793611d1c6a9b99df464812931a1e2d69)
+
 
 Co-authored-by: Elmar Ritsch <35851+elritsch@users.noreply.github.com>"""


### PR DESCRIPTION
Fixes https://github.com/python/core-workflow/issues/219