### PR TITLE
Add config file support to cherry_picker tool

### DIFF
--- a/cherry_picker/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker/cherry_picker.py
@@ -12,8 +12,10 @@ from gidgethub import sansio
 
 from . import __version__
 
-CPYTHON_CREATE_PR_URL = "https://api.github.com/repos/python/cpython/pulls"
-CPYTHON_CHECK_SHA = '7f777ed95a19224294949e1b4ce56bbffcb1fe9f'
+CREATE_PR_URL_TEMPLATE = "https://api.github.com/repos/{team}/{repo}/pulls"
+DEFAULT_TEAM = "python"
+DEFAULT_REPO = "cpython"
+DEFAULT_CHECK_SHA = '7f777ed95a19224294949e1b4ce56bbffcb1fe9f'
 
 class BranchCheckoutException(Exception):
     pass
@@ -31,7 +33,7 @@ class CherryPicker:
 
     def __init__(self, pr_remote, commit_sha1, branches,
                  *, dry_run=False, push=True,
-                 prefix_commit=True
+                 prefix_commit=True,
                  ):
 
         self.check_repo()  # may raise InvalidRepoException
@@ -214,7 +216,9 @@ Co-authored-by: {get_author_info_from_short_sha(self.commit_sha1)}"""
           "base": base_branch,
           "maintainer_can_modify": True
         }
-        response = requests.post(CPYTHON_CREATE_PR_URL, headers=request_headers, json=data)
+        url = CREATE_PR_URL_TEMPLATE.format(team=DEFAULT_TEAM,
+                                            repo=DEFAULT_REPO)
+        response = requests.post(url, headers=request_headers, json=data)
         if response.status_code == requests.codes.created:
             click.echo(f"Backport PR created at {response.json()['html_url']}")
         else:
@@ -335,7 +339,7 @@ To abort the cherry-pick and cleanup:
     def check_repo(self):
         # CPython repo has a commit with
         # SHA=7f777ed95a19224294949e1b4ce56bbffcb1fe9f
-        cmd = f"git log -r {CPYTHON_CHECK_SHA}"
+        cmd = f"git log -r {DEFAULT_CHECK_SHA}"
         try:
             subprocess.check_output(cmd.split(), stderr=subprocess.STDOUT)
         except subprocess.SubprocessError:

--- a/cherry_picker/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker/cherry_picker.py
@@ -15,13 +15,10 @@ from . import __version__
 CREATE_PR_URL_TEMPLATE = ("https://api.github.com/repos/"
                           "{config[github][team]}/{config[github][repo]}/"
                           "pulls")
-DEFAULT_TEAM = "python"
-DEFAULT_REPO = "cpython"
-DEFAULT_CHECK_SHA = '7f777ed95a19224294949e1b4ce56bbffcb1fe9f'
 DEFAULT_CONFIG = {'github':
-                  {'team': DEFAULT_TEAM,
-                   'repo': DEFAULT_REPO,
-                   'check_sha': DEFAULT_CHECK_SHA}}
+                  {'team': 'python',
+                   'repo': 'cpython',
+                   'check_sha': '7f777ed95a19224294949e1b4ce56bbffcb1fe9f'}}
 
 
 class BranchCheckoutException(Exception):

--- a/cherry_picker/cherry_picker/test.py
+++ b/cherry_picker/cherry_picker/test.py
@@ -1,3 +1,4 @@
+import pathlib
 from collections import ChainMap
 from unittest import mock
 
@@ -6,7 +7,8 @@ import pytest
 from .cherry_picker import get_base_branch, get_current_branch, \
     get_full_sha_from_short, get_author_info_from_short_sha, \
     CherryPicker, InvalidRepoException, \
-    normalize_commit_message, DEFAULT_CONFIG
+    normalize_commit_message, DEFAULT_CONFIG, \
+    find_project_root
 
 @pytest.fixture
 def config():
@@ -125,6 +127,12 @@ def test_is_not_cpython_repo():
     with pytest.raises(InvalidRepoException):
         CherryPicker('origin', '22a594a0047d7706537ff2ac676cdc0f1dcb329c',
                      ["3.6"])
+
+
+def test_find_project_root():
+    here = pathlib.Path(__file__)
+    root = here.parent.parent.parent
+    assert find_project_root() == root
 
 
 def test_normalize_long_commit_message():

--- a/cherry_picker/cherry_picker/test.py
+++ b/cherry_picker/cherry_picker/test.py
@@ -10,7 +10,7 @@ from .cherry_picker import get_base_branch, get_current_branch, \
 
 @pytest.fixture(autouse=True)
 def patch_cpython_sha():
-    cherry_picker.CPYTHON_CHECK_SHA = 'dc896437c8efe5a4a5dfa50218b7a6dc0cbe2598'
+    cherry_picker.DEFAULT_CHECK_SHA = 'dc896437c8efe5a4a5dfa50218b7a6dc0cbe2598'
 
 
 def test_get_base_branch():
@@ -115,7 +115,7 @@ Date:   Thu Aug 9 14:25:15 1990 +0000
 
 def test_is_not_cpython_repo():
     # revert back patch_cpython_sha fixture change
-    cherry_picker.CPYTHON_CHECK_SHA = '7f777ed95a19224294949e1b4ce56bbffcb1fe9f'
+    cherry_picker.DEFAULT_CHECK_SHA = '7f777ed95a19224294949e1b4ce56bbffcb1fe9f'
     with pytest.raises(InvalidRepoException):
         CherryPicker('origin', '22a594a0047d7706537ff2ac676cdc0f1dcb329c',
                      ["3.6"])

--- a/cherry_picker/pyproject.toml
+++ b/cherry_picker/pyproject.toml
@@ -9,7 +9,7 @@ author-email = "mariatta.wijaya@gmail.com"
 maintainer = "Python Core Developers"
 maintainer-email = "core-workflow@python.org"
 home-page = "https://github.com/python/core-workflow/tree/master/cherry_picker"
-requires = ["click~=6.7", "gidgethub", "requests"]
+requires = ["click~=6.7", "gidgethub", "requests", "toml"]
 dev-requires = ["pytest~=3.0.7"]
 description-file = "readme.rst"
 classifiers = ["Programming Language :: Python :: 3.6", "Intended Audience :: Developers", "License :: OSI Approved :: Apache Software License"]


### PR DESCRIPTION
As discussed in #225 

Custom project can put `.cherry_picker.toml` file in the repo root.
Example of file content for `aio-libs/aiohttp` project:
```
team = "aio-libs"
repo = "aiohttp"
check_sha = "f382b5ffc445e45a110734f5396728da7914aeb6"
```
`check_sha` is a full (long) sha1 for every project's pre-existing commit (the first initial commit is a good candidate).

If the file is not provided -- setting for `python/cpython` is substituted.

A path to config file could be overridden by passing `cherry_picker --config-path=my_custom_file.toml`.


Checked on aiohttp project, works like a charm.