### PR TITLE
Manage fixing commit message by config file setting

### DIFF
--- a/cherry_picker/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker/cherry_picker.py
@@ -20,7 +20,8 @@ CREATE_PR_URL_TEMPLATE = ("https://api.github.com/repos/"
 DEFAULT_CONFIG = collections.ChainMap({
     'team': 'python',
     'repo': 'cpython',
-    'check_sha': '7f777ed95a19224294949e1b4ce56bbffcb1fe9f'})
+    'check_sha': '7f777ed95a19224294949e1b4ce56bbffcb1fe9f',
+    'fix_commit_msg': True})
 
 
 class BranchCheckoutException(Exception):
@@ -122,8 +123,11 @@ class CherryPicker:
         """
         cmd = f"git show -s --format=%B {commit_sha}"
         output = subprocess.check_output(cmd.split(), stderr=subprocess.STDOUT)
-        updated_commit_message = output.strip().decode('utf-8').replace('#', 'GH-')
-        return updated_commit_message
+        message = output.strip().decode('utf-8')
+        if self.config['fix_commit_msg']:
+            return message.replace('#', 'GH-')
+        else:
+            return message
 
     def checkout_master(self):
         """ git checkout master """
@@ -175,7 +179,7 @@ To abort the cherry-pick and cleanup:
 
 
 Co-authored-by: {get_author_info_from_short_sha(self.commit_sha1)}"""
-        updated_commit_message = updated_commit_message.replace('#', 'GH-')
+        # updated_commit_message = updated_commit_message.replace('#', 'GH-')
         if self.dry_run:
             click.echo(f"  dry-run: git commit --amend -m '{updated_commit_message}'")
         else:

--- a/cherry_picker/cherry_picker/test.py
+++ b/cherry_picker/cherry_picker/test.py
@@ -123,6 +123,20 @@ def test_get_updated_commit_message(subprocess_check_output, os_path_exists,
            == 'bpo-123: Fix Spam Module (GH-113)'
 
 
+@mock.patch('os.path.exists')
+@mock.patch('subprocess.check_output')
+def test_get_updated_commit_message_without_links_replacement(
+        subprocess_check_output, os_path_exists, config):
+    os_path_exists.return_value = True
+    subprocess_check_output.return_value = b'bpo-123: Fix Spam Module (#113)'
+    config['fix_commit_msg'] = False
+    branches = ["3.6"]
+    cp = CherryPicker('origin', '22a594a0047d7706537ff2ac676cdc0f1dcb329c',
+                      branches, config=config)
+    assert cp.get_commit_message('22a594a0047d7706537ff2ac676cdc0f1dcb329c') \
+           == 'bpo-123: Fix Spam Module (#113)'
+
+
 @mock.patch('subprocess.check_output')
 def test_is_cpython_repo(subprocess_check_output, config):
     subprocess_check_output.return_value = """commit 7f777ed95a19224294949e1b4ce56bbffcb1fe9f
@@ -187,7 +201,8 @@ def test_load_config(tmpdir, cd):
     cfg = load_config(pathlib.Path(str(cfg)))
     assert cfg == {'check_sha': '7f777ed95a19224294949e1b4ce56bbffcb1fe9f',
                    'repo': 'core-workfolow',
-                   'team': 'python'}
+                   'team': 'python',
+                   'fix_commit_msg': True}
 
 
 def test_normalize_long_commit_message():

--- a/cherry_picker/readme.rst
+++ b/cherry_picker/readme.rst
@@ -102,27 +102,39 @@ Configuration file example::
    team = "aio-libs"
    repo = "aiohttp"
    check_sha = "f382b5ffc445e45a110734f5396728da7914aeb6"
+   fix_commit_msg = False
+
 
 Available config options::
 
-   team        github organization or individual nick,
-               e.g "aio-libs" for https://github.com/aio-libs/aiohttp
-               ("python" by default)
+   team            github organization or individual nick,
+                   e.g "aio-libs" for https://github.com/aio-libs/aiohttp
+                   ("python" by default)
 
-   repo        github project name,
-               e.g "aiohttp" for https://github.com/aio-libs/aiohttp
-               ("cpython" by default)
+   repo            github project name,
+                   e.g "aiohttp" for https://github.com/aio-libs/aiohttp
+                   ("cpython" by default)
 
-   check_sha   A long hash for any commit from the repo,
-               e.g. a sha1 hash from the very first initial commit
-               ("7f777ed95a19224294949e1b4ce56bbffcb1fe9f" by default)
+   check_sha       A long hash for any commit from the repo,
+                   e.g. a sha1 hash from the very first initial commit
+                   ("7f777ed95a19224294949e1b4ce56bbffcb1fe9f" by default)
+
+   fix_commit_msg  Replace # with GH- in cherry-picked commit message.
+                   It is the default behavior for CPython because of external
+                   Roundup bug tracker (https://bugs.python.org) behavior:
+                   #xxxx should point on issue xxxx but GH-xxxx points
+                   on pull-request xxxx.
+                   For projects with builtin GitHub bug tracker
+                   the option should be disabled most likely (set to False).
+
 
 To customize the tool for used by other project:
 
 1. Create a file called ``.cherry_picker.toml`` in the project's root
    folder (alongside with ``.git`` folder).
 
-2. Add ``team``, ``repo`` and ``check_sha`` config values as described above.
+2. Add ``team``, ``repo``, ``fix_commit_msg`` and ``check_sha``
+   config values as described above.
 
 3. Use ``git add .cherry_picker.toml`` / ``git commit`` to add the config
    into ``git``.


### PR DESCRIPTION
As discussed before `#` -> `GH-` replacement should be default behavior as required by CPython but we need a way to disable this replacement by config file settings.