### PR TITLE
Change single quotes to double quotes in get_author_info_from_short_sha to fix error in Windows

### DIFF
--- a/cherry_picker/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker/cherry_picker.py
@@ -437,7 +437,7 @@ def get_full_sha_from_short(short_sha):
 
 
 def get_author_info_from_short_sha(short_sha):
-    cmd = f"git log -1 --format='%aN <%ae>' {short_sha}"
+    cmd = f'git log -1 --format="%aN <%ae>" {short_sha}'
     output = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT)
     author = output.strip().decode('utf-8')
     return author


### PR DESCRIPTION
cherry_picker --continue breaks on Windows.

This happens because the process started from function get_author_info_from_short_sha is executed this way:

`C:\WINDOWS\system32\cmd.exe /c "git log -1 --format='%aN <%ae>' shortsha"`

The single quotes don't escape the angle brackets, so cmd tries to read the non-existent file "%ae", producing a "The system cannot find the file specified" error (this can be observed in stderr after editing subprocess.py)

Using double quotes fixes this.

Environment to reproduce the issue:

Windows 10 x64
Python 3.6.5 x64
Git for Windows 2.16.2 64-bit (running a bash-only configuration)

Traceback of the error:

```
🐍 🍒 ⛏
Traceback (most recent call last):
  File "c:\program files\python36\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "c:\program files\python36\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Program Files\Python36\Scripts\cherry_picker.exe\__main__.py", line 9, in <module>
  File "c:\program files\python36\lib\site-packages\click\core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "c:\program files\python36\lib\site-packages\click\core.py", line 697, in main
    rv = self.invoke(ctx)
  File "c:\program files\python36\lib\site-packages\click\core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "c:\program files\python36\lib\site-packages\click\core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "c:\program files\python36\lib\site-packages\cherry_picker\cherry_picker.py", line 402, in cherry_pick_cli
    cherry_picker.continue_cherry_pick()
  File "c:\program files\python36\lib\site-packages\cherry_picker\cherry_picker.py", line 328, in continue_cherry_pick
    co_author_info = f"Co-authored-by: {get_author_info_from_short_sha(short_sha)}"
  File "c:\program files\python36\lib\site-packages\cherry_picker\cherry_picker.py", line 441, in get_author_info_from_short_sha
    output = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT)
  File "c:\program files\python36\lib\subprocess.py", line 336, in check_output
    **kwargs).stdout
  File "c:\program files\python36\lib\subprocess.py", line 418, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command 'git log -1 --format='%aN <%ae>' b81ca28' returned non-zero exit status 1.
```