### PR TITLE
Explicit push location to ignore user git config

### DIFF
--- a/cherry_picker/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker/cherry_picker.py
@@ -202,7 +202,7 @@ Co-authored-by: {get_author_info_from_short_sha(self.commit_sha1)}"""
     def push_to_remote(self, base_branch, head_branch, commit_message=""):
         """ git push <origin> <branchname> """
 
-        cmd = ['git', 'push', self.pr_remote, head_branch]
+        cmd = ['git', 'push', self.pr_remote, f'{head_branch}:{head_branch}']
         try:
             self.run_cmd(cmd)
         except subprocess.CalledProcessError:


### PR DESCRIPTION
Users can configure what strategy "git push" uses to determine which
remote branch it should push to.  Cherry-picker doesn't work with all of
the git push strategies but we can make explicit what the remote branch
should be which works around that problem.


In my case, I had this in my .gitconfig (perhaps needed long ago when git used a less intuitive push strategy by default:
```
[push]
        default = tracking
```

That caused git to push to the remote that the branch was branched from rather than trying to push to a branch with the same name as the existing, local one.  Being explicit about both the local and remote branchname should just make the behaviour cherry_picker expects work in both default git configurations and customzed configurations.