### PR TITLE
Fix detection of upstream version branches with continue

### DIFF
--- a/cherry_picker/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker/cherry_picker.py
@@ -422,7 +422,7 @@ def get_base_branch(cherry_pick_branch):
     """
     return '2.7' from 'backport-sha-2.7'
     """
-    prefix, sep, base_branch = cherry_pick_branch.rpartition('-')
+    prefix, sha, base_branch = cherry_pick_branch.split('-', 2)
     return base_branch
 
 

--- a/cherry_picker/cherry_picker/test.py
+++ b/cherry_picker/cherry_picker/test.py
@@ -33,15 +33,16 @@ def cd():
 
 
 def test_get_base_branch():
+    # The format of cherry-pick branches we create are "backport-{SHA}-{base_branch}"
     cherry_pick_branch = 'backport-afc23f4-2.7'
     result = get_base_branch(cherry_pick_branch)
     assert result == '2.7'
 
 
-def test_get_base_branch_without_dash():
-    cherry_pick_branch ='master'
+def test_get_base_branch_which_has_dashes():
+    cherry_pick_branch ='backport-afc23f4-baseprefix-2.7-basesuffix'
     result = get_base_branch(cherry_pick_branch)
-    assert result == 'master'
+    assert result == 'baseprefix-2.7-basesuffix'
 
 
 @mock.patch('subprocess.check_output')


### PR DESCRIPTION
cherry_picker has recently grown support for prefixed version branches
(like stable-2.6).  The --continue support had a bug with those branches
where it wouldn't account for the fact that those branches could have
extra dashes in them and thus mixing branch name with sha.

This commit should fix those situations.