### PR TITLE
Validate a branch that we parse when running cherry_picker --continue 

### DIFF
--- a/cherry_picker/cherry_picker/test.py
+++ b/cherry_picker/cherry_picker/test.py
@@ -32,17 +32,34 @@ def cd():
     os.chdir(cwd)
 
 
-def test_get_base_branch():
-    # The format of cherry-pick branches we create are "backport-{SHA}-{base_branch}"
-    cherry_pick_branch = 'backport-afc23f4-2.7'
+@mock.patch('subprocess.check_output')
+def test_get_base_branch(subprocess_check_output):
+    # The format of cherry-pick branches we create are::
+    #     backport-{SHA}-{base_branch}
+    subprocess_check_output.return_value = b'22a594a0047d7706537ff2ac676cdc0f1dcb329c'
+    cherry_pick_branch = 'backport-22a594a-2.7'
     result = get_base_branch(cherry_pick_branch)
     assert result == '2.7'
 
 
-def test_get_base_branch_which_has_dashes():
-    cherry_pick_branch ='backport-afc23f4-baseprefix-2.7-basesuffix'
+@mock.patch('subprocess.check_output')
+def test_get_base_branch_which_has_dashes(subprocess_check_output):
+    subprocess_check_output.return_value = b'22a594a0047d7706537ff2ac676cdc0f1dcb329c'
+    cherry_pick_branch = 'backport-22a594a-baseprefix-2.7-basesuffix'
     result = get_base_branch(cherry_pick_branch)
     assert result == 'baseprefix-2.7-basesuffix'
+
+
+@pytest.mark.parametrize('cherry_pick_branch', ['backport-22a594a',  # Not enough fields
+                                                'prefix-22a594a-2.7',  # Not the prefix we were expecting
+                                                'backport-22a594a-base',  # No version info in the base branch
+                                                ]
+                         )
+@mock.patch('subprocess.check_output')
+def test_get_base_branch_invalid(subprocess_check_output, cherry_pick_branch):
+    subprocess_check_output.return_value = b'22a594a0047d7706537ff2ac676cdc0f1dcb329c'
+    with pytest.raises(ValueError):
+        get_base_branch(cherry_pick_branch)
 
 
 @mock.patch('subprocess.check_output')


### PR DESCRIPTION

When running cherry_picker --continue we count on being able to get
certain information from the branch's name which cherry_picker
constructed earlier.  Verify as best we can that the branch name is one
which cherry_picker could have constructed.

Relies on the changes here: #265
(which does the work of one of the validations)