### PR TITLE
[WIP] Warn in case news items contains multiple paragraphs.

### DIFF
--- a/blurb/blurb.py
+++ b/blurb/blurb.py
@@ -160,86 +160,60 @@ def textwrap_body(body, *, subsequent_indent=''):
     Accepts either a string or an iterable of strings.
     (Iterable is assumed to be individual lines.)
     Returns a string.
+
+    Step 1: remove trailing whitespace from individual lines
+      (this means that empty lines will just have \n, no invisible whitespace)
+    Step 2: wrap
+
+    Why do we reflow the text twice?  Because it can actually change
+    between the first and second reflows, and we want the text to
+    be stable.  The problem is that textwrap.wrap is deliberately
+    dumb about how many spaces follow a period in prose.
+
+    We're reflowing at 76 columns, but let's pretend it's 30 for
+    illustration purposes.  If we give textwrap.wrap the following
+    text--ignore the line of 30 dashes, that's just to help you
+    with visualization:
+
+     ------------------------------
+     xxxx xxxx xxxx xxxx xxxx.  xxxx
+
+    The first textwrap.wrap will return this:
+     "xxxx xxxx xxxx xxxx xxxx.\nxxxx"
+
+    If we reflow it again, textwrap will rejoin the lines, but
+    only with one space after the period!  So this time it'll
+    all fit on one line, behold:
+     ------------------------------
+     xxxx xxxx xxxx xxxx xxxx. xxxx
+    and so it now returns:
+     "xxxx xxxx xxxx xxxx xxxx. xxxx"
+
+    textwrap.wrap supports trying to add two spaces after a peroid:
+       https://docs.python.org/3/library/textwrap.html#textwrap.TextWrapper.fix_sentence_endings
+    But it doesn't work all that well, because it's not smart enough
+    to do a really good job.
+
+    Since blurbs are eventually turned into ReST and rendered anyway,
+    and since the Zen says "In the face of ambiguity, refuse the
+    temptation to guess", I don't sweat it.  I run textwrap.wrap
+    twice, so it's stable, and this means occasionally it'll
+    convert two spaces to one space, no big deal.
     """
     if isinstance(body, str):
         text = body
     else:
         text = "\n".join(body).rstrip()
 
-    # textwrap merges paragraphs, ARGH
-
-    # step 1: remove trailing whitespace from individual lines
-    #   (this means that empty lines will just have \n, no invisible whitespace)
     lines = []
     for line in text.split("\n"):
         lines.append(line.rstrip())
     text = "\n".join(lines)
-    # step 2: break into paragraphs and wrap those
-    paragraphs = text.split("\n\n")
-    paragraphs2 = []
-    kwargs = {'break_long_words': False, 'break_on_hyphens': False}
-    if subsequent_indent:
-        kwargs['subsequent_indent'] = subsequent_indent
-    dont_reflow = False
-    for paragraph in paragraphs:
-        # don't reflow bulleted / numbered lists
-        dont_reflow = dont_reflow or paragraph.startswith(("* ", "1. ", "#. "))
-        if dont_reflow:
-            initial = kwargs.get("initial_indent", "")
-            subsequent = kwargs.get("subsequent_indent", "")
-            if initial or subsequent:
-                lines = [line.rstrip() for line in paragraph.split("\n")]
-                indents = itertools.chain(
-                    itertools.repeat(initial, 1),
-                    itertools.repeat(subsequent),
-                    )
-                lines = [indent + line for indent, line in zip(indents, lines)]
-                paragraph = "\n".join(lines)
-            paragraphs2.append(paragraph)
-        else:
-            # Why do we reflow the text twice?  Because it can actually change
-            # between the first and second reflows, and we want the text to
-            # be stable.  The problem is that textwrap.wrap is deliberately
-            # dumb about how many spaces follow a period in prose.
-            #
-            # We're reflowing at 76 columns, but let's pretend it's 30 for
-            # illustration purposes.  If we give textwrap.wrap the following
-            # text--ignore the line of 30 dashes, that's just to help you
-            # with visualization:
-            #
-            #  ------------------------------
-            #  xxxx xxxx xxxx xxxx xxxx.  xxxx
-            #
-            # The first textwrap.wrap will return this:
-            #  "xxxx xxxx xxxx xxxx xxxx.\nxxxx"
-            #
-            # If we reflow it again, textwrap will rejoin the lines, but
-            # only with one space after the period!  So this time it'll
-            # all fit on one line, behold:
-            #  ------------------------------
-            #  xxxx xxxx xxxx xxxx xxxx. xxxx
-            # and so it now returns:
-            #  "xxxx xxxx xxxx xxxx xxxx. xxxx"
-            #
-            # textwrap.wrap supports trying to add two spaces after a peroid:
-            #    https://docs.python.org/3/library/textwrap.html#textwrap.TextWrapper.fix_sentence_endings
-            # But it doesn't work all that well, because it's not smart enough
-            # to do a really good job.
-            #
-            # Since blurbs are eventually turned into ReST and rendered anyway,
-            # and since the Zen says "In the face of ambiguity, refuse the
-            # temptation to guess", I don't sweat it.  I run textwrap.wrap
-            # twice, so it's stable, and this means occasionally it'll
-            # convert two spaces to one space, no big deal.
-
-            paragraph = "\n".join(textwrap.wrap(paragraph.strip(), width=76, **kwargs)).rstrip()
-            paragraph = "\n".join(textwrap.wrap(paragraph.strip(), width=76, **kwargs)).rstrip()
-            paragraphs2.append(paragraph)
-        # don't reflow literal code blocks (I hope)
-        dont_reflow = paragraph.endswith("::")
-        if subsequent_indent:
-            kwargs['initial_indent'] = subsequent_indent
-    text = "\n\n".join(paragraphs2).rstrip()
+    kwargs = {'break_long_words': False,
+              'break_on_hyphens': False,
+              'subsequent_indent': subsequent_indent}
+    text = "\n".join(textwrap.wrap(text.strip(), width=76, **kwargs)).rstrip()
+    text = "\n".join(textwrap.wrap(text.strip(), width=76, **kwargs)).rstrip()
     if not text.endswith("\n"):
         text += "\n"
     return text

--- a/blurb/blurb.py
+++ b/blurb/blurb.py
@@ -111,6 +111,9 @@ for line in template.split('\n'):
     if found and not prefix:
         sections.append(section.strip())
 
+def warn(*a):
+    return builtins.print('[WARNING]', *a, file=sys.stderr)
+
 
 def f(s):
     """
@@ -493,6 +496,10 @@ class Blurbs(list):
 
             if not body:
                 throw("Blurb 'body' text must not be empty!")
+            if "" in body[:-1]:
+                warn("Multiple paragraphs in {}:{}".format(filename, line_number - 2))
+                while "" in body[:-1]:
+                    body.remove("")
             text = textwrap_body(body)
             for naughty_prefix in ("- ", "Issue #", "bpo-"):
                 if text.startswith(naughty_prefix):


### PR DESCRIPTION
See https://bugs.python.org/issue32523, having multiple paragraphs in
a few news entry lead to inconsistent spacing while rendered in HTML.

Also NEWS entries should stay short, having multiple paragraphs is an
indicator the news entry is too long.

Currently, on cpython master, it yields around 60 warnings.

I'm also trying to fix them in https://github.com/python/cpython/pull/8154
