### PR TITLE
Better reporting in adverse conditions

### DIFF
--- a/blurb/blurb.py
+++ b/blurb/blurb.py
@@ -1108,14 +1108,14 @@ Python News
 git_add_files = []
 def flush_git_add_files():
     if git_add_files:
-        subprocess.run(["git", "add", "-f", *git_add_files]).check_returncode()
+        subprocess.run(["git", "add", "--force", *git_add_files]).check_returncode()
         git_add_files.clear()
 
 git_rm_files = []
 def flush_git_rm_files():
     if git_rm_files:
         try:
-            subprocess.run(["git", "rm", "--quiet", "-f", *git_rm_files]).check_returncode()
+            subprocess.run(["git", "rm", "--quiet", "--force", *git_rm_files]).check_returncode()
         except subprocess.CalledProcessError:
             pass
 

--- a/blurb/blurb.py
+++ b/blurb/blurb.py
@@ -1108,14 +1108,14 @@ Python News
 git_add_files = []
 def flush_git_add_files():
     if git_add_files:
-        subprocess.run(["git", "add", "-f", *git_add_files], stdout=subprocess.PIPE, stderr=subprocess.PIPE).check_returncode()
+        subprocess.run(["git", "add", "-f", *git_add_files]).check_returncode()
         git_add_files.clear()
 
 git_rm_files = []
 def flush_git_rm_files():
     if git_rm_files:
         try:
-            subprocess.run(["git", "rm", "-f", *git_rm_files], stdout=subprocess.PIPE, stderr=subprocess.PIPE).check_returncode()
+            subprocess.run(["git", "rm", "--quiet", "-f", *git_rm_files]).check_returncode()
         except subprocess.CalledProcessError:
             pass
 

--- a/blurb/blurb.py
+++ b/blurb/blurb.py
@@ -697,7 +697,7 @@ def chdir_to_repo_root():
     # find the root of the local CPython repo
     # note that we can't ask git, because we might
     # be in an exported directory tree!
-    
+
     # we intentionally start in a (probably nonexistant) subtree
     # the first thing the while loop does is .., basically
     path = os.path.abspath("garglemox")


### PR DESCRIPTION
In #275, I described an issue where a CalledProcessError occurs but no indication is reported, a condition that likely would have been reported if the output hadn't been suppressed.

Although a simple retry worked around the issue, it may happen again in the future, and it would be nice to know what is the cause. This change enables that.

In the third commit, this change also uses the long-form option to git, making it easier for someone troubleshooting an issue like this one unfamiliar with the meaning of `-f` to understand what's happening.