### PR TITLE
Loosen README check for CPython working directory

### DIFF
--- a/blurb/blurb.py
+++ b/blurb/blurb.py
@@ -715,7 +715,7 @@ def run(s):
     return process.stdout.decode('ascii')
 
 
-readme_re = re.compile(r"This is Python version [23]\.\d").match
+readme_re = re.compile(r"This is (Py|Tau)thon version [23]\.\d").match
 
 def chdir_to_repo_root():
     global root


### PR DESCRIPTION
Tauthon is a fork of CPython2.7 and has essentially the same organizational
and naming conventions that the prior code attempted to verify by evaluating
the 'Python version 2' regular expression against the first line of README.
Allow `blurb` to generate entries in the Tauthon fork by slightly relaxing
this regex.