### PR TITLE
Use Co-Authored-By instead of Co-authored-by.

### DIFF
--- a/cherry_picker/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker/cherry_picker.py
@@ -181,7 +181,7 @@ To abort the cherry-pick and cleanup:
 (cherry picked from commit {self.commit_sha1})
 
 
-Co-authored-by: {get_author_info_from_short_sha(self.commit_sha1)}"""
+Co-Authored-By: {get_author_info_from_short_sha(self.commit_sha1)}"""
         if self.dry_run:
             click.echo(f"  dry-run: git commit --amend -m '{updated_commit_message}'")
         else:
@@ -326,7 +326,7 @@ To abort the cherry-pick and cleanup:
             short_sha = cherry_pick_branch[cherry_pick_branch.index('-')+1:cherry_pick_branch.index(base)-1]
             full_sha = get_full_sha_from_short(short_sha)
             commit_message = self.get_commit_message(short_sha)
-            co_author_info = f"Co-authored-by: {get_author_info_from_short_sha(short_sha)}"
+            co_author_info = f"Co-Authored-By: {get_author_info_from_short_sha(short_sha)}"
             updated_commit_message = f"""[{base}] {commit_message}.
 (cherry picked from commit {full_sha})
 

--- a/cherry_picker/cherry_picker/test.py
+++ b/cherry_picker/cherry_picker/test.py
@@ -254,7 +254,7 @@ In Sphinx 1.5.1+, it is now "index.rst.txt".
 (cherry picked from commit b9ff498793611d1c6a9b99df464812931a1e2d69)
 
 
-Co-authored-by: Elmar Ritsch <35851+elritsch@users.noreply.github.com>"""
+Co-Authored-By: Elmar Ritsch <35851+elritsch@users.noreply.github.com>"""
     title, body = normalize_commit_message(commit_message)
     assert title == "[3.6] Fix broken `Show Source` links on documentation pages (GH-3113)"
     assert body == """The `Show Source` was broken because of a change made in sphinx 1.5.1
@@ -263,7 +263,7 @@ In Sphinx 1.5.1+, it is now "index.rst.txt".
 (cherry picked from commit b9ff498793611d1c6a9b99df464812931a1e2d69)
 
 
-Co-authored-by: Elmar Ritsch <35851+elritsch@users.noreply.github.com>"""
+Co-Authored-By: Elmar Ritsch <35851+elritsch@users.noreply.github.com>"""
 
 
 def test_normalize_short_commit_message():
@@ -272,10 +272,10 @@ def test_normalize_short_commit_message():
 (cherry picked from commit b9ff498793611d1c6a9b99df464812931a1e2d69)
 
 
-Co-authored-by: Elmar Ritsch <35851+elritsch@users.noreply.github.com>"""
+Co-Authored-By: Elmar Ritsch <35851+elritsch@users.noreply.github.com>"""
     title, body = normalize_commit_message(commit_message)
     assert title == "[3.6] Fix broken `Show Source` links on documentation pages (GH-3113)"
     assert body == """(cherry picked from commit b9ff498793611d1c6a9b99df464812931a1e2d69)
 
 
-Co-authored-by: Elmar Ritsch <35851+elritsch@users.noreply.github.com>"""
+Co-Authored-By: Elmar Ritsch <35851+elritsch@users.noreply.github.com>"""


### PR DESCRIPTION
I don't know whether this matters, but GitHub itself uses `Co-Authored-By` in approved suggestions.