### PR TITLE
cherry-picker: Run Travis CI test on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ sudo: false
 cache: pip
 
 before_install:
-- &install-flit
+- &install-flit >-
   pip install --upgrade flit
 
 .mixtures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,10 +105,13 @@ jobs:
     python: 3.7
     before_install:
       - choco install python --version 3.7
-      - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
       - python -m pip install --upgrade pip wheel
       - *install-flit
     <<: *install-and-test-cherry-picker
+    env:
+      PATH: >-
+        /c/Python37:/c/Python37/Scripts:$PATH
+      TARGET_PKG: cherry_picker
 
   - <<: *deploy-base
     <<: *run-if-blurb

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ sudo: false
 cache: pip
 
 before_install:
-- pip install --upgrade flit
+- &install-flit
+  pip install --upgrade flit
 
 .mixtures:
 - &run-if-tagged
@@ -98,6 +99,16 @@ jobs:
     <<: *run-if-cherry-picker
     env:
       TARGET_PKG: cherry_picker
+
+  - os: windows
+    language: sh
+    python: 3.7
+    before_install:
+      - choco install python --version 3.7
+      - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
+      - python -m pip install --upgrade pip wheel
+      - *install-flit
+    <<: *install-and-test-cherry-picker
 
   - <<: *deploy-base
     <<: *run-if-blurb

--- a/cherry_picker/cherry_picker/test.py
+++ b/cherry_picker/cherry_picker/test.py
@@ -84,9 +84,19 @@ def git_cherry_pick():
 
 
 @pytest.fixture
-def tmp_git_repo_dir(tmpdir, cd, git_init, git_commit):
+def git_config():
+    git_config_cmd = 'git', 'config'
+    return lambda *extra_args: (
+        subprocess.run(git_config_cmd + extra_args, check=True)
+    )
+
+
+@pytest.fixture
+def tmp_git_repo_dir(tmpdir, cd, git_init, git_commit, git_config):
     cd(tmpdir)
     git_init()
+    git_config('--local', 'user.name', 'Monty Python')
+    git_config('--local', 'user.email', 'bot@python.org')
     git_commit('Initial commit', '--allow-empty')
     yield tmpdir
 

--- a/cherry_picker/cherry_picker/test.py
+++ b/cherry_picker/cherry_picker/test.py
@@ -415,7 +415,9 @@ def test_from_git_rev_read_negative(
 def test_from_git_rev_read_uncommitted(tmp_git_repo_dir, git_add, git_commit):
     some_text = 'blah blah 🤖'
     relative_file_path = '.some.file'
-    tmp_git_repo_dir.join(relative_file_path).write(some_text)
+    (
+        pathlib.Path(tmp_git_repo_dir) / relative_file_path
+    ).write_text(some_text)
     git_add('.')
     with pytest.raises(ValueError):
         from_git_rev_read('HEAD:' + relative_file_path) == some_text
@@ -424,7 +426,9 @@ def test_from_git_rev_read_uncommitted(tmp_git_repo_dir, git_add, git_commit):
 def test_from_git_rev_read(tmp_git_repo_dir, git_add, git_commit):
     some_text = 'blah blah 🤖'
     relative_file_path = '.some.file'
-    tmp_git_repo_dir.join(relative_file_path).write(some_text)
+    (
+        pathlib.Path(tmp_git_repo_dir) / relative_file_path
+    ).write_text(some_text)
     git_add('.')
     git_commit('Add some file')
     assert from_git_rev_read('HEAD:' + relative_file_path) == some_text

--- a/cherry_picker/cherry_picker/test.py
+++ b/cherry_picker/cherry_picker/test.py
@@ -417,7 +417,7 @@ def test_from_git_rev_read_uncommitted(tmp_git_repo_dir, git_add, git_commit):
     relative_file_path = '.some.file'
     (
         pathlib.Path(tmp_git_repo_dir) / relative_file_path
-    ).write_text(some_text)
+    ).write_text(some_text, encoding='utf-8')
     git_add('.')
     with pytest.raises(ValueError):
         from_git_rev_read('HEAD:' + relative_file_path) == some_text
@@ -428,7 +428,7 @@ def test_from_git_rev_read(tmp_git_repo_dir, git_add, git_commit):
     relative_file_path = '.some.file'
     (
         pathlib.Path(tmp_git_repo_dir) / relative_file_path
-    ).write_text(some_text)
+    ).write_text(some_text, encoding='utf-8')
     git_add('.')
     git_commit('Add some file')
     assert from_git_rev_read('HEAD:' + relative_file_path) == some_text

--- a/cherry_picker/cherry_picker/test.py
+++ b/cherry_picker/cherry_picker/test.py
@@ -268,22 +268,16 @@ def test_is_not_cpython_repo():
                      ["3.6"])
 
 
-def test_find_config(tmpdir, cd):
-    cd(tmpdir)
-    subprocess.run('git init .'.split(), check=True)
+def test_find_config(tmp_git_repo_dir, git_add, git_commit):
     relative_config_path = '.cherry_picker.toml'
-    cfg = tmpdir.join(relative_config_path)
-    cfg.write('param = 1')
-    subprocess.run('git add .'.split(), check=True)
-    subprocess.run(('git', 'commit', '-m', 'Initial commit'), check=True)
+    tmp_git_repo_dir.join(relative_config_path).write('param = 1')
+    git_add(relative_config_path)
+    git_commit('Add config')
     scm_revision = get_sha1_from('HEAD')
-    assert find_config(scm_revision) == scm_revision + ':' + relative_config_path
+    assert find_config(scm_revision) == f'{scm_revision}:{relative_config_path}'
 
 
-def test_find_config_not_found(tmpdir, cd):
-    cd(tmpdir)
-    subprocess.run('git init .'.split(), check=True)
-    subprocess.run(('git', 'commit', '-m', 'Initial commit', '--allow-empty'), check=True)
+def test_find_config_not_found(tmp_git_repo_dir):
     scm_revision = get_sha1_from('HEAD')
     assert find_config(scm_revision) is None
 

--- a/cherry_picker/cherry_picker/test.py
+++ b/cherry_picker/cherry_picker/test.py
@@ -287,19 +287,16 @@ def test_find_config_not_git(tmpdir, cd):
     assert find_config(None) is None
 
 
-def test_load_full_config(tmpdir, cd):
-    cd(tmpdir)
-    subprocess.run('git init .'.split(), check=True)
+def test_load_full_config(tmp_git_repo_dir, git_add, git_commit):
     relative_config_path = '.cherry_picker.toml'
-    cfg = tmpdir.join(relative_config_path)
-    cfg.write('''\
+    tmp_git_repo_dir.join(relative_config_path).write('''\
     team = "python"
     repo = "core-workfolow"
     check_sha = "5f007046b5d4766f971272a0cc99f8461215c1ec"
     default_branch = "devel"
     ''')
-    subprocess.run('git add .'.split(), check=True)
-    subprocess.run(('git', 'commit', '-m', 'Initial commit'), check=True)
+    git_add(relative_config_path)
+    git_commit('Add config')
     scm_revision = get_sha1_from('HEAD')
     cfg = load_config(None)
     assert cfg == (
@@ -314,16 +311,13 @@ def test_load_full_config(tmpdir, cd):
     )
 
 
-def test_load_partial_config(tmpdir, cd):
-    cd(tmpdir)
-    subprocess.run('git init .'.split(), check=True)
+def test_load_partial_config(tmp_git_repo_dir, git_add, git_commit):
     relative_config_path = '.cherry_picker.toml'
-    cfg = tmpdir.join(relative_config_path)
-    cfg.write('''\
+    tmp_git_repo_dir.join(relative_config_path).write('''\
     repo = "core-workfolow"
     ''')
-    subprocess.run('git add .'.split(), check=True)
-    subprocess.run(('git', 'commit', '-m', 'Initial commit'), check=True)
+    git_add(relative_config_path)
+    git_commit('Add config')
     scm_revision = get_sha1_from('HEAD')
     cfg = load_config(relative_config_path)
     assert cfg == (


### PR DESCRIPTION
I've set up a Windows build on Travis before, maybe I can help #296 a bit!
There's no Python pre-installed, but there's a package manager, `choco`, that can install it.

Currently, the tests fail because they seem to require Git's `user.email` and `user.name` to be set globally. They fail on my dev machine as well, since I don't have an e-mail set globally (I use different e-mail addresses on different repos).
Sadly, I can't devote time to fixing that issue, but I can help to reproduce or explain more if needed.

To try out changes privately, here's what I do:
* [Enable Travis on your fork](https://travis-ci.org/account/repositories) of the repo
* Uncheck "Build pused branches" and "Build pushed pull requests" on your fork's Travis settings (you'll want to trigger builds manually)
* Push code you want to test to *your fork's master branch*
* Use "Trigger build in Travis's "More options" menu to trigger the build
* Cancel any builds you're not interested in (for example, all the Linux builds) to save both time and processing
