### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
-          - '3.11-dev'
+          - '3.11'
     name: ${{ matrix.python }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           cache: pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
+          - '3.11-dev'
     name: ${{ matrix.python }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,10 +15,12 @@ jobs:
     name: ${{ matrix.python }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python }}
+          cache: pip
+          cache-dependency-path: ".github/workflows/tests.yml"
       - name: setup
         run: |
           python --version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,12 +1,6 @@
 name: Tests
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build_ubuntu:


### PR DESCRIPTION
Allow testing feature branches, so contributors can check CI passes _before_ opening a PR.

Add `workflow_dispatch` to add a button, so builds can be manually triggered via the UI (like we could with Travis).

Test Python `3.11-dev`, the latest alpha/beta/RC.

Bump actions to `v3` and cache pip.