### PR TITLE
Replace `gh-issue-NNNN:` with `gh-NNNN:` in the output

### DIFF
--- a/blurb/blurb.py
+++ b/blurb/blurb.py
@@ -1113,7 +1113,7 @@ Python News
             if metadata.get("gh-issue"):
                 issue_number = metadata['gh-issue']
                 if int(issue_number):
-                    body = "gh-issue-" + issue_number + ": " + body
+                    body = "gh-" + issue_number + ": " + body
             elif metadata.get("bpo"):
                 issue_number = metadata['bpo']
                 if int(issue_number):


### PR DESCRIPTION
I noticed in python/cpython#92448 that the output shows `gh-issues-NNNN:` instead of `gh-NNNN:`.  I had initially proposed to use `gh-issue` instead of just `issue` in the content of the entry because in that case is ambiguous and people might have added the bpo number.  In the output there is no such problem, and `gh-NNNN` is enough.

AFAIU if this PR is applied, it will update older news entries too, right?