### PR TITLE
Mention org owners in the new triager template

### DIFF
--- a/.github/ISSUE_TEMPLATE/triage_membership.md
+++ b/.github/ISSUE_TEMPLATE/triage_membership.md
@@ -13,6 +13,7 @@ More details: https://devguide.python.org/triaging.html#becoming-a-member-of-the
 -->
 
 # Request for Python Triage membership
+@python/organization-owners, please add a new triager:
 
 <!-- replace with real info -->
 
@@ -21,3 +22,4 @@ More details: https://devguide.python.org/triaging.html#becoming-a-member-of-the
 | GitHub username   | @bedevere-bot |
 | bpo username   | bedevere     |
 | Additional info   | e.g. _"already a bpo triager"_, _"I've made 1 million PRs"_, _"recommended by @miss-islington"_| |
+


### PR DESCRIPTION
The devguide [suggests](https://github.com/python/devguide/pull/889/files) that owners should be mentioned when adding new members, so it would make sense to add the mention to the template.

@python/organization-owners, is it a good idea, or are you getting notifications some other way?