### PR TITLE
Loosen README check for CPython forks

### DIFF
--- a/blurb/blurb.py
+++ b/blurb/blurb.py
@@ -701,7 +701,7 @@ def run(s):
     return process.stdout.decode('ascii')
 
 
-readme_re = re.compile(r"This is Python version [23]\.\d").match
+readme_re = re.compile(r"This is \w+thon version [23]\.\d").match
 
 def chdir_to_repo_root():
     global root

--- a/blurb/blurb.py
+++ b/blurb/blurb.py
@@ -701,7 +701,7 @@ def run(s):
     return process.stdout.decode('ascii')
 
 
-readme_re = re.compile(r"This is \w+ version \d\.\d+").match
+readme_re = re.compile(r"This is \w+ version \d+\.\d+").match
 
 def chdir_to_repo_root():
     global root

--- a/blurb/blurb.py
+++ b/blurb/blurb.py
@@ -701,7 +701,7 @@ def run(s):
     return process.stdout.decode('ascii')
 
 
-readme_re = re.compile(r"This is \w+thon version [23]\.\d").match
+readme_re = re.compile(r"This is \w+ version \d\.\d+").match
 
 def chdir_to_repo_root():
     global root


### PR DESCRIPTION
This PR supersedes gh-291. A quote from https://github.com/python/core-workflow/pull/291#issuecomment-423268895 for context:

> If we wanted to accommodate CPython forks, we should not 'bless' Tauthon only. /`Py`/`.`/ would potentially also accommodate things like 'Brython'. But it is not clear to me that we want to do this, as it would subvert part of the apparent purpose of the function that uses the RE.

@terryjreedy I believe that `This is Python version 2.7 as modified and augmented by the xxx fork thereof` wording is long and clumsy, and so perceived as *This is Python something something... Looks like a wrong repo*.