### PR TITLE
Update fields for triage membership template

### DIFF
--- a/.github/ISSUE_TEMPLATE/triage_membership.md
+++ b/.github/ISSUE_TEMPLATE/triage_membership.md
@@ -1,12 +1,13 @@
 ---
 name: Python Triage Membership
 about: Request by a core dev for someone to join the Python Triage team
+title: "Request for Python triage membership: name"
 ---
 
 <!--
 Core developers can create this issue to nominate someone to the Python Triage team.
 
-Existing bug triagers on bpo and other Python contributors with elevated privileges can create this issue
+Existing bug triagers and other Python contributors with elevated privileges can create this issue
 to nominate themselves into the Python Triage team.
 
 More details: https://devguide.python.org/triaging.html#becoming-a-member-of-the-python-triage-team
@@ -20,6 +21,5 @@ More details: https://devguide.python.org/triaging.html#becoming-a-member-of-the
 |     | Description |
 | --- | -------------------------- |
 | GitHub username   | @bedevere-bot |
-| bpo username   | bedevere     |
 | Additional info   | e.g. _"I've made 1 million PRs"_, _"I like helping review and triage other people's issues and PRs"_, _"recommended by @miss-islington"_| |
 

--- a/.github/ISSUE_TEMPLATE/triage_membership.md
+++ b/.github/ISSUE_TEMPLATE/triage_membership.md
@@ -7,9 +7,6 @@ title: "Request for Python triage membership: name"
 <!--
 Core developers can create this issue to nominate someone to the Python Triage team.
 
-Existing bug triagers and other Python contributors with elevated privileges can create this issue
-to nominate themselves into the Python Triage team.
-
 More details: https://devguide.python.org/triaging.html#becoming-a-member-of-the-python-triage-team
 -->
 


### PR DESCRIPTION
Remove "bpo username" from the table: even if new triagers have BPO usernames, I don't think we need this information any more.

Add "Request for Python triage membership: name" as a title for the template, so it's prefilled when creating a new request issue.
