### PR TITLE
Rename default branch from "master" to "main"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ blurb
 Interactive utility for writing CPython ``Misc/NEWS.d`` entries. See
 the blurb_ directory for more details.
 
-.. _blurb: https://github.com/python/core-workflow/tree/master/blurb
+.. _blurb: https://github.com/python/core-workflow/tree/main/blurb
 
 
 Other core workflow tools

--- a/blurb/pyproject.toml
+++ b/blurb/pyproject.toml
@@ -8,7 +8,7 @@ author = "Larry Hastings"
 author-email = "larry@hastings.org"
 maintainer = "Python Core Developers"
 maintainer-email = "core-workflow@mail.python.org"
-home-page = "https://github.com/python/core-workflow/tree/master/blurb"
+home-page = "https://github.com/python/core-workflow/tree/main/blurb"
 requires-python = ">=3.7"
 description-file = "README.rst"
 classifiers = [


### PR DESCRIPTION
To match most of the other https://github.com/python repos, let's use `main` as the default branch.

Please could @python/organization-owners rename it?

Docs here: 

* https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch