### PR TITLE
Improved error checking when parsing a Blurb.

### DIFF
--- a/blurb/tests/fail/invalid-gh-number.rst
+++ b/blurb/tests/fail/invalid-gh-number.rst
@@ -1,0 +1,4 @@
+.. gh-issue: abcde
+.. section: Library
+
+Things, stuff.

--- a/blurb/tests/fail/invalid-section.rst
+++ b/blurb/tests/fail/invalid-section.rst
@@ -1,0 +1,4 @@
+.. gh-issue: 8675309
+.. section: Funky Kong
+
+This is an invalid blurb.  Shockingly, "Funky Kong" is not a valid section name.

--- a/blurb/tests/fail/no-gh-number.rst
+++ b/blurb/tests/fail/no-gh-number.rst
@@ -1,0 +1,4 @@
+.. gh-issue:
+.. section: Library
+
+Things, stuff.

--- a/blurb/tests/fail/no-section.rst
+++ b/blurb/tests/fail/no-section.rst
@@ -1,0 +1,3 @@
+.. gh-issue: 8675309
+
+This is an invalid blurb.  It doesn't have a "section".


### PR DESCRIPTION
We now:
* Check the entries in metadata in order, so we complain about the *first* one that has an error, which is a more familiar user experience.
* Have checks for:
	* Invalid issue number
	* Invalid section
	* Empty section
	* Completely missing section

(There is no test for "missing issue number", because it's legal to have a Blurb with no issue number.  "no changes" blurbs don't have an issue number.  But we do now reliably test that, *if* the issue number is specified, it *is* correctly formatted.)