### PR TITLE
Only accept GH issues numbered 32426 or above

### DIFF
--- a/blurb/blurb.py
+++ b/blurb/blurb.py
@@ -942,10 +942,13 @@ Add a blurb (a Misc/NEWS.d/next entry) to the current CPython repo.
             failure = str(e)
 
         if not failure:
-            assert len(blurb) # if parse_blurb succeeds, we should always have a body
-            if len(blurb) > 1:
-                failure = "Too many entries!  Don't specify '..' on a line by itself."
-
+            with open(tmp_path, "rt", encoding="utf-8") as file:
+                for line in file:
+                    if line.startswith(".. gh-issue:"):
+                        issue_number = line.split(":")[1].strip()
+                        if issue_number.isdigit() and int(issue_number) < 32426:
+                            failure = "The gh-issue number should be 32426 or above."
+                            break
         if failure:
             print()
             print(f"Error: {failure}")


### PR DESCRIPTION
Fixes #504.

Iterates through the template file to find the gh-issue line and checks number if it's in the accepted issue number range.

This is how an unsuccessful attempt looks like:

```sh
❯ /bin/python3 /path/core-workflow/blurb/blurb.py

Error: The gh-issue number should be 32426 or above.

[Hit return to retry (or Ctrl-C to abort)> 
```