### PR TITLE
Accept GitHub issues numbered only 32426 or above

### DIFF
--- a/blurb/blurb.py
+++ b/blurb/blurb.py
@@ -489,7 +489,7 @@ class Blurbs(list):
                 # we see in the blurb file, which is a
                 # better user experience.
                 if key == "gh-issue" and int(value) < lowest_possible_gh_issue_number:
-                    throw("The gh-issue number must be 32426 or above, not a PR number.")
+                    throw(f"The gh-issue number must be {lowest_possible_gh_issue_number} or above, not a PR number.")
 
                 if key in issue_keys:
                     try:

--- a/blurb/blurb.py
+++ b/blurb/blurb.py
@@ -956,13 +956,14 @@ Add a blurb (a Misc/NEWS.d/next entry) to the current CPython repo.
             failure = str(e)
 
         if not failure:
-            with open(tmp_path, "rt", encoding="utf-8") as file:
-                for line in file:
-                    if line.startswith(".. gh-issue:"):
-                        issue_number = line.split(":")[1].strip()
-                        if issue_number.isdigit() and int(issue_number) < 32426:
-                            failure = "The gh-issue number should be 32426 or above."
-                            break
+            assert len(blurb)  # if parse_blurb succeeds, we should always have a body
+            if len(blurb) > 1:
+                failure = "Too many entries!  Don't specify '..' on a line by itself."
+            gh_issue_number = blurb[0][0]["gh-issue"]
+            if not gh_issue_number.isdigit():
+                failure = "The gh-issue number must be a number."
+            if int(gh_issue_number) < 32426:
+                failure = "The gh-issue number should be 32426 or above."
 
         if failure:
             print()

--- a/blurb/blurb.py
+++ b/blurb/blurb.py
@@ -486,6 +486,9 @@ class Blurbs(list):
                 # we'll complain about the *first* error
                 # we see in the blurb file, which is a
                 # better user experience.
+                if key == "gh-issue" and int(value) < 32426:
+                    throw("The gh-issue number should be 32426 or above.")
+
                 if key in issue_keys:
                     try:
                         int(value)
@@ -959,11 +962,6 @@ Add a blurb (a Misc/NEWS.d/next entry) to the current CPython repo.
             assert len(blurb)  # if parse_blurb succeeds, we should always have a body
             if len(blurb) > 1:
                 failure = "Too many entries!  Don't specify '..' on a line by itself."
-            gh_issue_number = blurb[0][0]["gh-issue"]
-            if not gh_issue_number.isdigit():
-                failure = "The gh-issue number must be a number."
-            if int(gh_issue_number) < 32426:
-                failure = "The gh-issue number should be 32426 or above."
 
         if failure:
             print()

--- a/blurb/blurb.py
+++ b/blurb/blurb.py
@@ -489,7 +489,7 @@ class Blurbs(list):
                 # we see in the blurb file, which is a
                 # better user experience.
                 if key == "gh-issue" and int(value) < lowest_possible_gh_issue_number:
-                    throw("The gh-issue number should be 32426 or above.")
+                    throw("The gh-issue number must be 32426 or above, not a PR number.")
 
                 if key in issue_keys:
                     try:

--- a/blurb/blurb.py
+++ b/blurb/blurb.py
@@ -473,6 +473,8 @@ class Blurbs(list):
 
             no_changes = metadata.get('no changes')
 
+            lowest_possible_gh_issue_number = 32426
+
             issue_keys = {
                 'gh-issue': 'GitHub',
                 'bpo': 'bpo',
@@ -486,7 +488,7 @@ class Blurbs(list):
                 # we'll complain about the *first* error
                 # we see in the blurb file, which is a
                 # better user experience.
-                if key == "gh-issue" and int(value) < 32426:
+                if key == "gh-issue" and int(value) < lowest_possible_gh_issue_number:
                     throw("The gh-issue number should be 32426 or above.")
 
                 if key in issue_keys:
@@ -959,7 +961,7 @@ Add a blurb (a Misc/NEWS.d/next entry) to the current CPython repo.
             failure = str(e)
 
         if not failure:
-            assert len(blurb)  # if parse_blurb succeeds, we should always have a body
+            assert len(blurb) # if parse_blurb succeeds, we should always have a body
             if len(blurb) > 1:
                 failure = "Too many entries!  Don't specify '..' on a line by itself."
 

--- a/blurb/blurb.py
+++ b/blurb/blurb.py
@@ -956,9 +956,13 @@ Add a blurb (a Misc/NEWS.d/next entry) to the current CPython repo.
             failure = str(e)
 
         if not failure:
-            assert len(blurb) # if parse_blurb succeeds, we should always have a body
-            if len(blurb) > 1:
-                failure = "Too many entries!  Don't specify '..' on a line by itself."
+            with open(tmp_path, "rt", encoding="utf-8") as file:
+                for line in file:
+                    if line.startswith(".. gh-issue:"):
+                        issue_number = line.split(":")[1].strip()
+                        if issue_number.isdigit() and int(issue_number) < 32426:
+                            failure = "The gh-issue number should be 32426 or above."
+                            break
 
         if failure:
             print()

--- a/blurb/tests/fail/small-gh-number.rst
+++ b/blurb/tests/fail/small-gh-number.rst
@@ -1,0 +1,4 @@
+.. gh-issue: 100
+.. section: Library
+
+This is an invalid blurb. GitHub issues should be 32426 or above.

--- a/blurb/tests/pass/basic.rst
+++ b/blurb/tests/pass/basic.rst
@@ -1,5 +1,5 @@
 .. date: 2017-05-02
-.. gh-issue: 0
+.. gh-issue: 40000
 .. nonce: xyz
 .. section: Library
 

--- a/blurb/tests/pass/basic.rst.res
+++ b/blurb/tests/pass/basic.rst.res
@@ -1,5 +1,5 @@
 .. date: 2017-05-02
-.. gh-issue: 0
+.. gh-issue: 40000
 .. nonce: xyz
 .. section: Library
 

--- a/blurb/tests/pass/case-insensitive.rst
+++ b/blurb/tests/pass/case-insensitive.rst
@@ -1,5 +1,5 @@
 .. date: 2017-05-02
-.. GH-Issue: 0
+.. GH-Issue: 35000
 .. nonce: xyz
 .. section: Library
 

--- a/blurb/tests/pass/case-insensitive.rst.res
+++ b/blurb/tests/pass/case-insensitive.rst.res
@@ -1,5 +1,5 @@
 .. date: 2017-05-02
-.. gh-issue: 0
+.. gh-issue: 35000
 .. nonce: xyz
 .. section: Library
 

--- a/blurb/tests/pass/no-break-long-words.rst
+++ b/blurb/tests/pass/no-break-long-words.rst
@@ -1,5 +1,5 @@
 .. date: 1234
-.. gh-issue: 0
+.. gh-issue: 35000
 .. nonce: xyz
 .. section: Library
 

--- a/blurb/tests/pass/no-break-long-words.rst.res
+++ b/blurb/tests/pass/no-break-long-words.rst.res
@@ -1,5 +1,5 @@
 .. date: 1234
-.. gh-issue: 0
+.. gh-issue: 35000
 .. nonce: xyz
 .. section: Library
 

--- a/blurb/tests/pass/no-break-on-hyphens.rst
+++ b/blurb/tests/pass/no-break-on-hyphens.rst
@@ -1,5 +1,5 @@
 .. date: 7333
-.. gh-issue: 21121
+.. gh-issue: 41121
 .. nonce: ZLsRil
 .. section: Library
 

--- a/blurb/tests/pass/no-break-on-hyphens.rst.res
+++ b/blurb/tests/pass/no-break-on-hyphens.rst.res
@@ -1,5 +1,5 @@
 .. date: 7333
-.. gh-issue: 21121
+.. gh-issue: 41121
 .. nonce: ZLsRil
 .. section: Library
 


### PR DESCRIPTION
Fixes https://github.com/python/core-workflow/issues/504.

Iterates through the template file to find the gh-issue line and checks number if it's in the accepted issue number range.

This is how an unsuccessful attempt looks like:

```sh
❯ /bin/python3 /path/core-workflow/blurb/blurb.py

Error: The gh-issue number should be 32426 or above.

[Hit return to retry (or Ctrl-C to abort)>
```