### PR TITLE
blurb: Add tests and run on CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,12 @@
+# .coveragerc to control coverage.py
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_also =
+    # Don't complain if non-runnable code isn't run:
+    if __name__ == .__main__.:
+    def main
+
+[run]
+omit =
+    **/blurb/__main__.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,7 @@ env:
 jobs:
   build_ubuntu:
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
     name: ${{ matrix.python-version }}
@@ -23,7 +24,7 @@ jobs:
         run: |
           python --version
           python -m pip install --upgrade pip
-          python -m pip install --upgrade pytest pytest-cov pyfakefs
+          python -m pip install --upgrade build pytest pytest-cov pyfakefs
       - name: install
         run: |
           cd blurb

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,6 @@ jobs:
         run: |
           python --version
           python -m pip install --upgrade pip
-          python -m pip install --upgrade flit
           python -m pip install --upgrade pytest pytest-cov pyfakefs
       - name: install
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     name: ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     steps:
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
           cache: pip
           cache-dependency-path: ".github/workflows/tests.yml"
       - name: setup
@@ -33,13 +34,9 @@ jobs:
         run: |
           blurb test
       - name: pytest
-        # TODO Pending https://github.com/pytest-dev/pyfakefs/issues/770
-        if: matrix.python-version != '3.12-dev'
         run: |
           python -I -m pytest --cov blurb
       - name: Upload coverage
-        # TODO Pending https://github.com/pytest-dev/pyfakefs/issues/770
-        if: matrix.python-version != '3.12-dev'
         uses: codecov/codecov-action@v3
         with:
           flags: ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,12 +24,11 @@ jobs:
         run: |
           python --version
           python -m pip install --upgrade pip
-          python -m pip install --upgrade build pytest pytest-cov pyfakefs
+          python -m pip install --upgrade pytest pytest-cov pyfakefs
       - name: install
         run: |
           cd blurb
-          python -m build
-          echo dist/*.whl | xargs -I % python -m pip install %
+          python -m pip install -e .
       - name: test
         run: |
           blurb test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,8 @@ jobs:
     name: ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,8 @@ jobs:
       - name: install
         run: |
           cd blurb
-          pip install -e .
+          python -m build
+          echo dist/*.whl | xargs -I % python -m pip install %
       - name: test
         run: |
           blurb test
@@ -35,7 +36,7 @@ jobs:
         # TODO Pending https://github.com/pytest-dev/pyfakefs/issues/770
         if: matrix.python-version != '3.12-dev'
         run: |
-          pytest --cov blurb
+          python -I -m pytest --cov blurb
       - name: Upload coverage
         # TODO Pending https://github.com/pytest-dev/pyfakefs/issues/770
         if: matrix.python-version != '3.12-dev'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,9 @@ name: Tests
 
 on: [push, pull_request, workflow_dispatch]
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   build_ubuntu:
     strategy:
@@ -21,10 +24,23 @@ jobs:
           python --version
           python -m pip install --upgrade pip
           python -m pip install --upgrade flit
+          python -m pip install --upgrade pytest pytest-cov pyfakefs
       - name: install
         run: |
           cd blurb
-          flit install
+          pip install -e .
       - name: test
         run: |
           blurb test
+      - name: pytest
+        # TODO Pending https://github.com/pytest-dev/pyfakefs/issues/770
+        if: matrix.python-version != '3.12-dev'
+        run: |
+          pytest --cov blurb
+      - name: Upload coverage
+        # TODO Pending https://github.com/pytest-dev/pyfakefs/issues/770
+        if: matrix.python-version != '3.12-dev'
+        uses: codecov/codecov-action@v3
+        with:
+          flags: ${{ matrix.python-version }}
+          name: Python ${{ matrix.python-version }}

--- a/blurb/blurb.py
+++ b/blurb/blurb.py
@@ -51,7 +51,6 @@ import hashlib
 import io
 import inspect
 import itertools
-import math
 import os
 from pathlib import Path
 import re
@@ -247,40 +246,6 @@ class pushd:
 def safe_mkdir(path):
     if not os.path.exists(path):
         os.makedirs(path)
-
-
-def which(cmd, path="PATH"):
-    """Find cmd on PATH."""
-    if os.path.exists(cmd):
-        return cmd
-    if cmd[0] == '/':
-        return None
-    for segment in os.getenv(path).split(":"):
-        program = os.path.normpath(os.path.join(segment, cmd))
-        if os.path.exists(program):
-            return program
-    return None
-
-
-def strip_whitespace_lines(lines):
-    # strip from head
-    while lines:
-        if lines[0]:
-            break
-        lines.pop(0)
-
-    # strip from tail
-    while lines:
-        if lines[-1]:
-            return
-        lines.pop()
-
-
-def longest_line(lines):
-    longest = 0
-    for line in lines:
-        longest = max(longest, len(line))
-    return longest
 
 
 def version_key(element):
@@ -639,31 +604,6 @@ Returns a dict.
         blurb.save(filename)
         return filename
 
-    def save_split_next(self):
-        """
-        Save out blurbs created from "blurb split".
-        They don't have dates, so we have to get creative.
-        """
-        filenames = []
-        # the "date" MUST have a leading zero.
-        # this ensures these files sort after all
-        # newly created blurbs.
-        width = int(math.ceil(math.log(len(self), 10))) + 1
-        i = 1
-        blurb = Blurbs()
-        while self:
-            metadata, body = self.pop()
-            metadata['date'] = str(i).rjust(width, '0')
-            if 'release date' in metadata:
-                del metadata['release date']
-            blurb.append((metadata, body))
-            filename = blurb._extract_next_filename()
-            blurb.save(filename)
-            blurb.clear()
-            filenames.append(filename)
-            i += 1
-        return filenames
-
 
 tests_run = 0
 
@@ -699,13 +639,6 @@ class TestParserFailures(TestParserPasses):
         b = Blurbs()
         with self.assertRaises(Exception):
             b.load(filename)
-
-
-
-def run(s):
-    process = subprocess.run(s.split(), capture_output=True)
-    process.check_returncode()
-    return process.stdout.decode('ascii')
 
 
 readme_re = re.compile(r"This is \w+ version \d+\.\d+").match
@@ -1007,7 +940,6 @@ This is used by the release manager when cutting a new release.
         metadata = {"no changes": "True", "gh-issue": "0", "section": "Library", "date": date, "nonce": nonceify(body)}
         blurbs.append((metadata, body))
     else:
-        no_changes = None
         count = len(filenames)
         print(f'Merging {count} blurbs to "{output}".')
 

--- a/blurb/tests/test_blurb.py
+++ b/blurb/tests/test_blurb.py
@@ -5,29 +5,49 @@ import blurb
 
 
 @pytest.mark.parametrize(
-    "section, expected",
+    "section",
     (
-        ("C API", "C API"),
-        ("Core and Builtins", "Core and Builtins"),
-        ("Library", "Library"),
-        ("Tools/Demos", "Tools-Demos"),
+        "C API",
+        "Core and Builtins",
+        "Library",
     ),
 )
-def test_sanitize_section(section: str, expected: str) -> None:
+def test_sanitize_section_no_change(section: str) -> None:
     sanitized = blurb.sanitize_section(section)
-    assert sanitized == expected
+    assert sanitized == section
 
 
 @pytest.mark.parametrize(
     "section, expected",
     (
-        ("C API", "C API"),
-        ("Core and Builtins", "Core and Builtins"),
-        ("Library", "Library"),
+        ("Tools/Demos", "Tools-Demos"),
+    ),
+)
+def test_sanitize_section_changed(section: str, expected: str) -> None:
+    sanitized = blurb.sanitize_section(section)
+    assert sanitized == expected
+
+
+@pytest.mark.parametrize(
+    "section",
+    (
+        "C API",
+        "Core and Builtins",
+        "Library",
+    ),
+)
+def test_unsanitize_section_no_change(section: str) -> None:
+    unsanitized = blurb.unsanitize_section(section)
+    assert unsanitized == section
+
+
+@pytest.mark.parametrize(
+    "section, expected",
+    (
         ("Tools-Demos", "Tools/Demos"),
     ),
 )
-def test_unsanitize_section(section: str, expected: str) -> None:
+def test_unsanitize_section_changed(section: str, expected: str) -> None:
     unsanitized = blurb.unsanitize_section(section)
     assert unsanitized == expected
 

--- a/blurb/tests/test_blurb.py
+++ b/blurb/tests/test_blurb.py
@@ -4,14 +4,14 @@ from pyfakefs.fake_filesystem import FakeFilesystem
 import blurb
 
 
-@pytest.mark.parametrize(
-    "section",
-    (
-        "C API",
-        "Core and Builtins",
-        "Library",
-    ),
+UNCHANGED_SECTIONS = (
+    "C API",
+    "Core and Builtins",
+    "Library",
 )
+
+
+@pytest.mark.parametrize("section", UNCHANGED_SECTIONS)
 def test_sanitize_section_no_change(section: str) -> None:
     sanitized = blurb.sanitize_section(section)
     assert sanitized == section
@@ -28,14 +28,7 @@ def test_sanitize_section_changed(section: str, expected: str) -> None:
     assert sanitized == expected
 
 
-@pytest.mark.parametrize(
-    "section",
-    (
-        "C API",
-        "Core and Builtins",
-        "Library",
-    ),
-)
+@pytest.mark.parametrize("section", UNCHANGED_SECTIONS)
 def test_unsanitize_section_no_change(section: str) -> None:
     unsanitized = blurb.unsanitize_section(section)
     assert unsanitized == section

--- a/blurb/tests/test_blurb.py
+++ b/blurb/tests/test_blurb.py
@@ -1,0 +1,127 @@
+import pytest
+from pyfakefs.fake_filesystem import FakeFilesystem
+
+import blurb
+
+
+@pytest.mark.parametrize(
+    "section, expected",
+    (
+        ("C API", "C API"),
+        ("Core and Builtins", "Core and Builtins"),
+        ("Library", "Library"),
+        ("Tools/Demos", "Tools-Demos"),
+    ),
+)
+def test_sanitize_section(section: str, expected: str) -> None:
+    sanitized = blurb.sanitize_section(section)
+    assert sanitized == expected
+
+
+@pytest.mark.parametrize(
+    "section, expected",
+    (
+        ("C API", "C API"),
+        ("Core and Builtins", "Core and Builtins"),
+        ("Library", "Library"),
+        ("Tools-Demos", "Tools/Demos"),
+    ),
+)
+def test_unsanitize_section(section: str, expected: str) -> None:
+    unsanitized = blurb.unsanitize_section(section)
+    assert unsanitized == expected
+
+
+def test_glob_blurbs_next(fs: FakeFilesystem) -> None:
+    # Arrange
+    fake_news_entries = (
+        "Misc/NEWS.d/next/Library/2022-04-11-18-34-33.gh-issue-11111.pC7gnM.rst",
+        "Misc/NEWS.d/next/Core and Builtins/2023-03-17-12-09-45.gh-issue-33333.Pf_BI7.rst",
+        "Misc/NEWS.d/next/Tools-Demos/2023-03-21-01-27-07.gh-issue-44444.2F1Byz.rst",
+        "Misc/NEWS.d/next/C API/2023-03-27-22-09-07.gh-issue-66666.3SN8Bs.rst",
+    )
+    fake_readmes = (
+        "Misc/NEWS.d/next/Library/README.rst",
+        "Misc/NEWS.d/next/Core and Builtins/README.rst",
+        "Misc/NEWS.d/next/Tools-Demos/README.rst",
+        "Misc/NEWS.d/next/C API/README.rst",
+    )
+    for fn in fake_news_entries + fake_readmes:
+        fs.create_file(fn)
+
+    # Act
+    filenames = blurb.glob_blurbs("next")
+
+    # Assert
+    assert set(filenames) == set(fake_news_entries)
+
+
+@pytest.mark.parametrize(
+    "news_entry, expected_section",
+    (
+        (
+            "Misc/NEWS.d/next/Library/2022-04-11-18-34-33.gh-issue-11111.pC7gnM.rst",
+            "Library",
+        ),
+        (
+            "Misc/NEWS.d/next/Core and Builtins/2023-03-17-12-09-45.gh-issue-33333.Pf_BI7.rst",
+            "Core and Builtins",
+        ),
+        (
+            "Misc/NEWS.d/next/Tools-Demos/2023-03-21-01-27-07.gh-issue-44444.2F1Byz.rst",
+            "Tools/Demos",
+        ),
+        (
+            "Misc/NEWS.d/next/C API/2023-03-27-22-09-07.gh-issue-66666.3SN8Bs.rst",
+            "C API",
+        ),
+    ),
+)
+def test_load_next(news_entry: str, expected_section: str, fs: FakeFilesystem) -> None:
+    # Arrange
+    fs.create_file(news_entry, contents="testing")
+    blurbs = blurb.Blurbs()
+
+    # Act
+    blurbs.load_next(news_entry)
+
+    # Assert
+    metadata = blurbs[0][0]
+    assert metadata["section"] == expected_section
+
+
+@pytest.mark.parametrize(
+    "news_entry, expected_path",
+    (
+        (
+            "Misc/NEWS.d/next/Library/2022-04-11-18-34-33.gh-issue-11111.pC7gnM.rst",
+            "root/Misc/NEWS.d/next/Library/2022-04-11-18-34-33.gh-issue-11111.pC7gnM.rst",
+        ),
+        (
+            "Misc/NEWS.d/next/Core and Builtins/2023-03-17-12-09-45.gh-issue-33333.Pf_BI7.rst",
+            "root/Misc/NEWS.d/next/Core and Builtins/2023-03-17-12-09-45.gh-issue-33333.Pf_BI7.rst",
+        ),
+        (
+            "Misc/NEWS.d/next/Tools-Demos/2023-03-21-01-27-07.gh-issue-44444.2F1Byz.rst",
+            "root/Misc/NEWS.d/next/Tools-Demos/2023-03-21-01-27-07.gh-issue-44444.2F1Byz.rst",
+        ),
+        (
+            "Misc/NEWS.d/next/C API/2023-03-27-22-09-07.gh-issue-66666.3SN8Bs.rst",
+            "root/Misc/NEWS.d/next/C API/2023-03-27-22-09-07.gh-issue-66666.3SN8Bs.rst",
+        ),
+    ),
+)
+def test_extract_next_filename(
+    news_entry: str, expected_path: str, fs: FakeFilesystem
+) -> None:
+    # Arrange
+    fs.create_file(news_entry, contents="testing")
+    blurb.root = "root"
+    blurbs = blurb.Blurbs()
+    blurbs.load_next(news_entry)
+
+    # Act
+    path = blurbs._extract_next_filename()
+
+    # Assert
+    assert path == expected_path

--- a/blurb/tests/test_blurb.py
+++ b/blurb/tests/test_blurb.py
@@ -73,7 +73,7 @@ def test_glob_blurbs_next(fs: FakeFilesystem) -> None:
     "news_entry, expected_section",
     (
         (
-            "Misc/NEWS.d/next/Library/2022-04-11-18-34-33.gh-issue-11111.pC7gnM.rst",
+            "Misc/NEWS.d/next/Library/2022-04-11-18-34-33.gh-issue-55555.pC7gnM.rst",
             "Library",
         ),
         (
@@ -107,8 +107,8 @@ def test_load_next(news_entry: str, expected_section: str, fs: FakeFilesystem) -
     "news_entry, expected_path",
     (
         (
-            "Misc/NEWS.d/next/Library/2022-04-11-18-34-33.gh-issue-11111.pC7gnM.rst",
-            "root/Misc/NEWS.d/next/Library/2022-04-11-18-34-33.gh-issue-11111.pC7gnM.rst",
+            "Misc/NEWS.d/next/Library/2022-04-11-18-34-33.gh-issue-55555.pC7gnM.rst",
+            "root/Misc/NEWS.d/next/Library/2022-04-11-18-34-33.gh-issue-55555.pC7gnM.rst",
         ),
         (
             "Misc/NEWS.d/next/Core and Builtins/2023-03-17-12-09-45.gh-issue-33333.Pf_BI7.rst",


### PR DESCRIPTION
This splits out the testing added in https://github.com/python/core-workflow/pull/499 to its own PR, to make reviewing of both easier.

These tests are useful even if #499 is not merged.