### PR TITLE
blurb: Drop support for EOL Python 3.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,8 +10,8 @@ jobs:
     name: ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
   build_ubuntu:
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12-dev"]
     name: ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
   build_ubuntu:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     name: ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     steps:

--- a/blurb/README.rst
+++ b/blurb/README.rst
@@ -25,7 +25,7 @@ and automatically uses the correct file paths.
 
 You can install **blurb** from PyPI using ``pip``.  Alternatively,
 simply add ``blurb`` to a directory on your path.
-**blurb**'s only dependency is Python 3.7+.
+**blurb**'s only dependency is Python 3.8+.
 
 
 Files used by blurb

--- a/blurb/pyproject.toml
+++ b/blurb/pyproject.toml
@@ -9,7 +9,7 @@ author-email = "larry@hastings.org"
 maintainer = "Python Core Developers"
 maintainer-email = "core-workflow@mail.python.org"
 home-page = "https://github.com/python/core-workflow/tree/main/blurb"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 description-file = "README.rst"
 classifiers = [
     "Intended Audience :: Developers",


### PR DESCRIPTION
Re: https://devguide.python.org/versions/