### PR TITLE
Add tox for easy testing of many Python versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+name: Lint
+
+on: [push, pull_request, workflow_dispatch]
+
+env:
+  FORCE_COLOR: 1
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ env:
   FORCE_COLOR: 1
 
 jobs:
-  build_ubuntu:
+  test:
     strategy:
       fail-fast: false
       matrix:
@@ -15,27 +15,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
           cache: pip
-          cache-dependency-path: ".github/workflows/tests.yml"
-      - name: setup
+
+      - name: Install dependencies
         run: |
           python --version
           python -m pip install --upgrade pip
-          python -m pip install --upgrade pytest pytest-cov pyfakefs
-      - name: install
+          python -m pip install --upgrade tox
+
+      - name: Tox tests
         run: |
           cd blurb
+          tox -e py
+
           python -m pip install -e .
-      - name: test
-        run: |
-          blurb test
-      - name: pytest
-        run: |
-          python -I -m pytest --cov blurb
+
       - name: Upload coverage
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     name: ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-toml
+      - id: check-yaml
+      - id: debug-statements
+
+  - repo: https://github.com/tox-dev/tox-ini-fmt
+    rev: 1.3.1
+    hooks:
+      - id: tox-ini-fmt
+
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+      - id: check-useless-excludes
+
+ci:
+  autoupdate_schedule: quarterly

--- a/blurb/pyproject.toml
+++ b/blurb/pyproject.toml
@@ -1,21 +1,33 @@
 [build-system]
-requires = ["flit_core >=2,<4"]
 build-backend = "flit_core.buildapi"
-
-[tool.flit.metadata]
-module = "blurb"
-author = "Larry Hastings"
-author-email = "larry@hastings.org"
-maintainer = "Python Core Developers"
-maintainer-email = "core-workflow@mail.python.org"
-home-page = "https://github.com/python/core-workflow/tree/main/blurb"
-requires-python = ">=3.8"
-description-file = "README.rst"
-classifiers = [
-    "Intended Audience :: Developers",
-    "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3 :: Only"
+requires = [
+  "flit_core<4,>=2",
 ]
 
-[tool.flit.scripts]
+[project]
+name = "blurb"
+description = "Command-line tool to manage CPython Misc/NEWS.d entries."
+readme = "README.rst"
+maintainers = [{name = "Python Core Developers", email="core-workflow@mail.python.org"}]
+authors = [{ name="Larry Hastings", email="larry@hastings.org"}]
+requires-python = ">=3.8"
+classifiers = [
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: BSD License",
+  "Programming Language :: Python :: 3 :: Only",
+]
+dynamic = [
+  "version",
+]
+[project.optional-dependencies]
+tests = [
+  "pyfakefs",
+  "pytest",
+  "pytest-cov",
+]
+[project.urls]
+Changelog = "https://github.com/python/core-workflow/tree/main/blurb#changelog"
+Homepage = "https://github.com/python/core-workflow/tree/main/blurb"
+Source = "https://github.com/python/core-workflow/tree/main/blurb"
+[project.scripts]
 blurb = "blurb:main"

--- a/blurb/tox.ini
+++ b/blurb/tox.ini
@@ -1,0 +1,21 @@
+[tox]
+requires =
+    tox>=4.2
+env_list =
+    py{313, 312, 311, 310, 39, 38}
+
+[testenv]
+extras =
+    tests
+pass_env =
+    FORCE_COLOR
+commands =
+    {envpython} -I -m pytest \
+      --cov blurb \
+      --cov tests \
+      --cov-report html \
+      --cov-report term \
+      --cov-report xml \
+      {posargs}
+    blurb test
+    blurb help


### PR DESCRIPTION
The tox tool makes it easy to test by taking care of the virtualenv for you and installing dependencies (defined by a `tests` "extra"). It also makes it easy to test multiple Python versions.

For example:

```sh
# Test Python 3.12
tox -e py312

# Test Python 3.12 and pass an argument to pytest
tox -e py312 -- --stepwise

# Test all available Python versions in serial
tox

# Test all available Python versions in parallel
tox -p auto
```

This PR also:

* Adds support for Python 3.13
* Updates `pyproject.toml` to use standard metadata instead of tool-specific (flit), so we can add a `tests` extra to `[project.optional-dependencies]`
* Adds simple pre-commit config for linting, and to the CI
