### PR TITLE
Fix link to devguide Triage Team page

### DIFF
--- a/.github/ISSUE_TEMPLATE/triage_membership.md
+++ b/.github/ISSUE_TEMPLATE/triage_membership.md
@@ -7,7 +7,7 @@ title: "Request for Python triage membership: name"
 <!--
 Core developers can create this issue to nominate someone to the Python Triage team.
 
-More details: https://devguide.python.org/triaging.html#becoming-a-member-of-the-python-triage-team
+More details: https://devguide.python.org/triage/triage-team/#becoming-a-member-of-the-python-triage-team
 -->
 
 # Request for Python Triage membership


### PR DESCRIPTION
The redirect sends you to the wrong page, i.e. "Triaging an issue" and not "Becoming a member of the Python triage team".